### PR TITLE
In getOMWMappingSuffix, use Unicode escapes instead of direct characters.

### DIFF
--- a/src/java/com/articulate/sigma/OMWordnet.java
+++ b/src/java/com/articulate/sigma/OMWordnet.java
@@ -43,10 +43,10 @@ August 9, Acapulco, Mexico.
         
         switch (WordNetUtilities.getSUMOMappingSuffix(SUMOmapping)) {
             case '=': return '='; 
-            case '+': return '⊂'; 
-            case '@': return '∈'; 
-            case ':': return '≠'; 
-            case '[': return '⊃'; 
+            case '+': return '\u2282'; // '⊂';
+            case '@': return '\u2208'; // '∈';
+            case ':': return '\u2260'; // '≠';
+            case '[': return '\u2283'; // '⊃';
         }
         return ' ';
     }


### PR DESCRIPTION
My Java compiler (version 1.8.0_91 on Windows) doesn't like direct Unicode character literals like '∈'. So, changed to use the Unicode escapes like '\u2208'. I believe I got the right Unicode values from https://en.wikipedia.org/wiki/Mathematical_operators_and_symbols_in_Unicode.