### PR TITLE
Replace various hardcoded paths

### DIFF
--- a/src/java/com/articulate/sigma/EProver.java
+++ b/src/java/com/articulate/sigma/EProver.java
@@ -413,7 +413,7 @@ public class EProver {
         String initialDatabase = "SUMO-v.kif";
         EProver eprover = EProver.getNewInstance(initialDatabase);
         eprover.setCommandLineOptions("--cpu-limit=600 --soft-cpu-limit=500 -xAuto -tAuto -l 4 --tptp3-in");
-        KBmanager.getMgr().setPref("eprover","/home/apease/Programs/E/Prover/eprover");
+        KBmanager.getMgr().setPref("eprover",System.getProperty("user.home") + "/Programs/E/Prover/eprover");
         System.out.print(eprover.submitQuery("(holds instance ?X Relation)",5,2));
         */
         try {

--- a/src/java/com/articulate/sigma/Hotel.java
+++ b/src/java/com/articulate/sigma/Hotel.java
@@ -1755,7 +1755,7 @@ public class Hotel {
                 path = args[1];
             execJSON(path);
         }
-        //parseOneJSONReviewFile("/home/apease/Rearden/Schema/TA/2992-Arlington.json");
+        //parseOneJSONReviewFile(System.getProperty("user.home") + "/Rearden/Schema/TA/2992-Arlington.json");
         
         //HotelDBImport();
         //System.out.println(topSUMOInReviews());

--- a/src/java/com/articulate/sigma/InferenceTestSuite.java
+++ b/src/java/com/articulate/sigma/InferenceTestSuite.java
@@ -478,7 +478,7 @@ public class InferenceTestSuite {
 
         try {
             KBmanager.getMgr().initializeOnce();
-            KBmanager.getMgr().setPref("inferenceTestDir","/home/apease/infTest");
+            KBmanager.getMgr().setPref("inferenceTestDir",System.getProperty("user.home") + "/infTest");
             KB kb = KBmanager.getMgr().getKB("SUMO");
             System.out.println(InferenceTestSuite.test(kb, "STP2", 10));
         } catch (Exception e) {

--- a/src/java/com/articulate/sigma/KBmanager.java
+++ b/src/java/com/articulate/sigma/KBmanager.java
@@ -96,7 +96,7 @@ public class KBmanager {
     /** ***************************************************************
      * Set default attribute values if not in the configuration file.
      */
-    private void setDefaultAttributes() {
+    public void setDefaultAttributes() {
         
         try {
             String sep = File.separator;

--- a/src/java/com/articulate/sigma/NER.java
+++ b/src/java/com/articulate/sigma/NER.java
@@ -22,7 +22,7 @@ public class NER {
         String newcore = KBmanager.getMgr().getPref("stanford-ner");
         if (!StringUtil.emptyString(newcore))
         	stanfordCore = newcore;
-        String execString = System.getProperty("user.home") + "/Programs/java/jdk1.8.0_25/bin/java -mx700m " +
+        String execString = System.getProperty("java.home") + "/java -mx700m " +
                 "-classpath " + stanfordCore + "/stanford-ner.jar " +
                 "edu.stanford.nlp.ie.crf.CRFClassifier " +
                 //                 "-loadClassifier " + System.getProperty("user.home") + "/Programs/stanford-ner-2014-10-26/classifiers/english.all.3class.distsim.crf.ser.gz " +

--- a/src/java/com/articulate/sigma/NER.java
+++ b/src/java/com/articulate/sigma/NER.java
@@ -18,16 +18,16 @@ public class NER {
         BufferedReader _reader; 
         BufferedWriter _writer; 
         BufferedReader _error;
-        String stanfordCore = "/home/apease/Programs/stanford-ner-2014-10-26";
+        String stanfordCore = System.getProperty("user.home") + "/Programs/stanford-ner-2014-10-26";
         String newcore = KBmanager.getMgr().getPref("stanford-ner");
         if (!StringUtil.emptyString(newcore))
         	stanfordCore = newcore;
-        String execString = "/home/apease/Programs/java/jdk1.8.0_25/bin/java -mx700m " +
+        String execString = System.getProperty("user.home") + "/Programs/java/jdk1.8.0_25/bin/java -mx700m " +
                 "-classpath " + stanfordCore + "/stanford-ner.jar " +
                 "edu.stanford.nlp.ie.crf.CRFClassifier " +
-                //                 "-loadClassifier  /home/apease/Programs/stanford-ner-2014-10-26/classifiers/english.all.3class.distsim.crf.ser.gz " +
-                //                 "-loadClassifier  /home/apease/Programs/stanford-ner-2014-10-26/classifiers/english.nowiki.3class.distsim.crf.ser.gz " +
-                //                 "-loadClassifier  /home/apease/Programs/stanford-ner-2014-10-26/classifiers/english.conll.4class.distsim.crf.ser.gz " +
+                //                 "-loadClassifier " + System.getProperty("user.home") + "/Programs/stanford-ner-2014-10-26/classifiers/english.all.3class.distsim.crf.ser.gz " +
+                //                 "-loadClassifier " + System.getProperty("user.home") + "/Programs/stanford-ner-2014-10-26/classifiers/english.nowiki.3class.distsim.crf.ser.gz " +
+                //                 "-loadClassifier " + System.getProperty("user.home") + "/Programs/stanford-ner-2014-10-26/classifiers/english.conll.4class.distsim.crf.ser.gz " +
                 "-loadClassifier " + stanfordCore + "/classifiers/english.muc.7class.distsim.crf.ser.gz " +
                 "-textFile " + infile;
         System.out.println("INFO in NER.extractEntities(): executing: " + execString);

--- a/src/java/com/articulate/sigma/SimpleDOMParser.java
+++ b/src/java/com/articulate/sigma/SimpleDOMParser.java
@@ -362,7 +362,7 @@ public class SimpleDOMParser {
         try {
             //String _projectFileName = "projects-energy.xml";
             //fname = KBmanager.getMgr().getPref("baseDir") + File.separator + _projectFileName;
-            fname = "/home/apease/corpora/timebank_1_2/data/extra/wsj_0991.tml";
+            fname = System.getProperty("user.home") + "/corpora/timebank_1_2/data/extra/wsj_0991.tml";
             System.out.println(fname);
             File f = new File(fname);
             if (!f.exists()) 

--- a/src/java/com/articulate/sigma/WSD.java
+++ b/src/java/com/articulate/sigma/WSD.java
@@ -531,7 +531,7 @@ public class WSD {
             // pair_ID sentence_A sentence_B entailment_label relatedness_score entailment_AB entailment_BA sentence_A_original
             // sentence_B_original sentence_A_dataset sentence_B_dataset SemEval_set
             String line;
-            String f = "/home/apease/ontology/SICK/SICK.txt";
+            String f = System.getProperty("user.home") + "/ontology/SICK/SICK.txt";
             File sickFile = new File(f);
             if (sickFile == null) {
                 System.out.println("Error in WSD.readSick(): The file does not exist in " + f );
@@ -565,7 +565,7 @@ public class WSD {
 
         FileWriter fw = null;
         PrintWriter pw = null;
-        String fname = "/home/apease/ontology/SICK/SickOut.txt";
+        String fname = System.getProperty("user.home") + "/ontology/SICK/SickOut.txt";
 
         try {
             fw = new FileWriter(fname);

--- a/src/java/com/articulate/sigma/trans/TPTP3ProofProcessor.java
+++ b/src/java/com/articulate/sigma/trans/TPTP3ProofProcessor.java
@@ -510,7 +510,7 @@ public class TPTP3ProofProcessor {
 		KB kb = null;
 		TPTP3ProofProcessor tpp = new TPTP3ProofProcessor();
 		try {
-			FileReader r = new FileReader("/home/apease/Programs/E/PROVER/eltb_out.txt");
+			FileReader r = new FileReader(System.getProperty("user.home") + "/Programs/E/PROVER/eltb_out.txt");
 			LineNumberReader lnr = new LineNumberReader(r);
 			tpp = parseProofOutput(lnr, kb);
 		}
@@ -531,8 +531,8 @@ public class TPTP3ProofProcessor {
 			//KB kb = KBmanager.getMgr().getKB("SUMO");
 			KB kb = null;
 			System.out.println("------------- INFO in EProver.main() completed initialization--------");
-			EProver eprover = new EProver("/home/apease/Programs/E/PROVER/e_ltb_runner",
-					"/home/apease/Sigma/KBs/SUMO.tptp");
+			EProver eprover = new EProver(System.getProperty("user.home") + "/Programs/E/PROVER/e_ltb_runner",
+					System.getProperty("user.home") + "/.sigmakee/KBs/SUMO.tptp");
 
 			String result = eprover.submitQuery("(subclass Patio Object)",kb);
 			StringReader sr = new StringReader(result);

--- a/src/java/com/articulate/sigma/trans/TPTP3ProofProcessor.java
+++ b/src/java/com/articulate/sigma/trans/TPTP3ProofProcessor.java
@@ -532,7 +532,7 @@ public class TPTP3ProofProcessor {
 			KB kb = null;
 			System.out.println("------------- INFO in EProver.main() completed initialization--------");
 			EProver eprover = new EProver(System.getProperty("user.home") + "/Programs/E/PROVER/e_ltb_runner",
-					System.getProperty("user.home") + "/.sigmakee/KBs/SUMO.tptp");
+					System.getenv("SIGMA_HOME") + "/KBs/SUMO.tptp");
 
 			String result = eprover.submitQuery("(subclass Patio Object)",kb);
 			StringReader sr = new StringReader(result);

--- a/src/java/com/articulate/sigma/wordNet/BrownCorpus.java
+++ b/src/java/com/articulate/sigma/wordNet/BrownCorpus.java
@@ -227,7 +227,7 @@ public class BrownCorpus {
     public static void main(String[] args) {
 
         BrownCorpus bc = new BrownCorpus();
-        bc.read("/home/apease/ontology/brown");
+        bc.read(System.getProperty("user.home") + "/ontology/brown");
         bc.process();
     }
 }

--- a/test/unit/java/com/articulate/sigma/SigmaTestBase.java
+++ b/test/unit/java/com/articulate/sigma/SigmaTestBase.java
@@ -35,6 +35,7 @@ public class SigmaTestBase {
             }
 
             manager.initializing = true;
+            KBmanager.getMgr().setDefaultAttributes();
             KBmanager.getMgr().setConfiguration(configuration);
             manager.initialized = true;
             manager.initializing = false;

--- a/test/unit/java/com/articulate/sigma/UnitTestBase.java
+++ b/test/unit/java/com/articulate/sigma/UnitTestBase.java
@@ -18,7 +18,7 @@ public class UnitTestBase  extends SigmaTestBase {
             "test/unit/java/resources";
     private static final String CONFIG_FILE_PATH = CONFIG_FILE_DIR + File.separator +
             "config_topOnly.xml";
-    //private static final String CONFIG_FILE_PATH = "/home/apease/.sigmakee/KBs/config.xml";
+    //private static final String CONFIG_FILE_PATH = System.getenv("SIGMA_HOME") + "/KBs/config.xml";
     private static final Class CLASS = UnitTestBase.class;
     public static final int NUM_KIF_FILES = 4;  // include cache file
 

--- a/test/unit/java/resources/config_topOnly.xml
+++ b/test/unit/java/resources/config_topOnly.xml
@@ -6,12 +6,12 @@
   <preference name="userBrowserLimit" value="25" />
   <preference name="hostname" value="localhost" />
   <preference name="loadCELT" value="no" />
-  <preference name="baseDir" value="/home/apease/.sigmakee" />
   <preference name="showcached" value="yes" />
-  <preference name="kbDir" value="/home/apease/.sigmakee/KBs" />
   <preference name="typePrefix" value="yes" />
   <preference name="TPTP" value="yes" />
   <preference name="holdsPrefix" value="no" />
+  <preference name="inferenceEngine" value="" />
+  <preference name="leoExecutable" value="" />
   <kb name="SUMO">
     <constituent filename="Merge.kif" />
     <constituent filename="english_format.kif" />


### PR DESCRIPTION
This PR parallels ontologyportal/sigmanlp#3: it replaces explicit references to `/home/apease`, `.sigmakee`, and the java binary with appropriate System properties, etc.

In addition, this PR alters the unit test config file to use default values for `baseDir` and `kbDir` (which are based on `SIGMA_HOME`) rather than user-specific absolute paths, and makes the necessary changes to KBmanager and SigmaTestBase for that to be possible.