### PR TITLE
adding MacOS documentation

### DIFF
--- a/INSTALL.MacOS
+++ b/INSTALL.MacOS
@@ -57,8 +57,10 @@ these variables created before the next step:
   export CATALINA_HOME=~/workspace/apache-tomcat-8.5.23
   export SIGMA_CP=$SIGMA_HOME/sigmakee/build/classes:$SIGMA_HOME/sigmakee/build/lib/*:$SIGMA_HOME/sigmakee/lib/*
 
-cd ~/workspace/sigmakee
+pushd ~/workspace/sigmakee
 ant
+popd
+popd
 
 Follow the steps in section "Account Management" from the README.txt below to set up accounts
 

--- a/INSTALL.MacOS
+++ b/INSTALL.MacOS
@@ -29,7 +29,7 @@ git clone https://github.com/ontologyportal/sigmakee
 git clone https://github.com/ontologyportal/sumo
 
 curl -O 'http://wordnetcode.princeton.edu/3.0/WordNet-3.0.tar.gz'
-tar xvfz WordNet-3.0.tar
+tar xvfz WordNet-3.0.tar.gz
 cp -iav WordNet-3.0/dict/* ~/workspace/sumo/WordNetMappings/
 rm WordNet-3.0.tar.gz
 
@@ -52,6 +52,7 @@ these variables created before the next step:
 
   ## SUMO/SIGMAKEE
   export SIGMA_HOME=~/workspace 
+  export SIGMA_SRC=~/workspace/sigmakee
   export ONTOLOGYPORTAL_GIT=~/workspace
   export CATALINA_OPTS="-Xms500M -Xmx2500M" 
   export CATALINA_HOME=~/workspace/apache-tomcat-8.5.23

--- a/INSTALL.MacOS
+++ b/INSTALL.MacOS
@@ -1,0 +1,83 @@
+MacOS install notes
+===================
+
+- you need curl or wget to download files, you can install both with
+  Homebrew.
+- java will be installed in /usr/libexec/java_home
+- get git from the xcode tools with "xcode-select --install”
+- instead of .bashrc edit .bash_profile
+- install Homebrew from http://brew.sh and the packages:
+
+brew install make
+brew install gcc
+brew install git
+brew install graphviz
+brew install ant
+
+Next, execute step-by-step the commands below (tested on MacOS 10.14.5):
+
+cd 
+mkdir workspace
+pushd workspace
+
+curl -O 'https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.23/bin/apache-tomcat-8.5.23.zip'
+unzip apache-tomcat-8.5.23.zip
+rm apache-tomcat-8.5.23.zip
+chmod 777 apache-tomcat-8.5.23/bin/*
+
+git clone https://github.com/ontologyportal/sigmakee
+git clone https://github.com/ontologyportal/sumo
+
+curl -O 'http://wordnetcode.princeton.edu/3.0/WordNet-3.0.tar.gz'
+tar xvfz WordNet-3.0.tar
+cp -iav WordNet-3.0/dict/* ~/workspace/sumo/WordNetMappings/
+rm WordNet-3.0.tar.gz
+
+curl -O 'http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_2.0/E.tgz'
+tar xvzf E.tgz
+pushd E
+./configure
+make
+make install (this step is optional, it will copy E files to /usr/local making it available for the whole system)
+popd
+
+cp sigmakee/config.xml sumo/
+(edit the config.xml changing all `~` to the value of `$HOME` and adapting all variables)
+
+ln -s sumo KBs
+(because there are many places in the java code that reference the "KBs" string)
+
+Add the following lines in your .profile and make sure to have all
+these variables created before the next step:
+
+  ## SUMO/SIGMAKEE
+  export SIGMA_HOME=~/workspace 
+  export ONTOLOGYPORTAL_GIT=~/workspace
+  export CATALINA_OPTS="-Xms500M -Xmx2500M" 
+  export CATALINA_HOME=~/workspace/apache-tomcat-8.5.23
+  export SIGMA_CP=$SIGMA_HOME/sigmakee/build/classes:$SIGMA_HOME/sigmakee/build/lib/*:$SIGMA_HOME/sigmakee/lib/*
+
+cd ~/workspace/sigmakee
+ant
+
+Follow the steps in section "Account Management" from the README.txt below to set up accounts
+
+To test run
+
+java  -Xmx2500m -classpath $SIGMA_CP com.articulate.sigma.KB
+
+To start Tomcat execute
+
+$CATALINA_HOME/bin/startup.sh
+
+Point your browser at http://localhost:8080/sigma/login.html
+
+
+Debugging
+
+- If login.html redirects you to init.jsp that means the system is
+  still initializing. Wait a minute or two and try again.
+
+- If you are on mac and getting errors related to not finding jars
+  when running com.articulate.sigma.KB, copy all jars from
+  ~/workspace/sigmakee/build/lib/ to /Library/Java/Extensions

--- a/README.txt
+++ b/README.txt
@@ -246,79 +246,10 @@ again.
 from /home/theuser/workspace/sigmakee/build/lib/ to /Library/Java/Extensions
 
 
-Apple install notes
+MacOS install notes
 ===================
 
-use "curl -o filename URL" if you don't have wget installed
-java will be installed in /usr/libexec/java_home
-get git from the xcode tools - "xcode-select --install"
-instead of .bashrc edit .bash_profile
-
-install Homebrew from http://brew.sh
-
-mkdir workspace
-mkdir Programs
-cd Programs
-curl -O 'https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.23/bin/apache-tomcat-8.5.23.zip'
-curl -O 'http://wordnetcode.princeton.edu/3.0/WordNet-3.0.tar.gz'
-curl -O 'http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_2.0/E.tgz'
-tar -xvzf E.tgz
-unzip apache-tomcat-8.5.23.zip
-rm apache-tomcat-8.5.23.zip
-cd ~/Programs/apache-tomcat-8.5.23/bin
-chmod 777 *
-cd ~/workspace/
-sudo apt-get install git
-git clone https://github.com/ontologyportal/sigmakee
-git clone https://github.com/ontologyportal/sumo
-cd ~
-mkdir .sigmakee
-cd .sigmakee
-mkdir KBs
-cp -R ~/workspace/sumo/* KBs
-me="$(whoami)"
-cp ~/workspace/sigmakee/config.xml ~/.sigmakee/KBs
-sed -i "s/theuser/$me/g" config.xml
-cd ~/Programs
-gunzip WordNet-3.0.tar.gz
-tar -xvf WordNet-3.0.tar
-cp WordNet-3.0/dict/* ~/.sigmakee/KBs/WordNetMappings/
-cd ~/Programs/E
-brew install make
-brew install gcc
-./configure
-make
-make install
-cd ~
-brew install graphviz
-echo "export SIGMA_HOME=~/.sigmakee" >> .bash_profile
-echo "export ONTOLOGYPORTAL_GIT=~/workspace" >> .bash_profile
-echo "export CATALINA_OPTS=\"$CATALINA_OPTS -Xms500M -Xmx2500M\"" >> .bash_profile
-echo "export CATALINA_HOME=~/Programs/apache-tomcat-8.5.23" >> .bash_profile
-source .bash_profile
-cd ~/workspace/sigmakee
-brew install ant
-ant
-
-Follow the steps in section "Account Management" below to set up accounts
-
-To test run
-
-  java  -Xmx2500m -classpath ~/workspace/sigmakee/build/classes:~/workspace/sigmakee/build/lib/*
-    com.articulate.sigma.KB
-
-
-Start Tomcat with
-  $CATALINA_HOME/bin/startup.sh
-
-Point your browser at http://localhost:8080/sigma/login.html
-
-
-Debugging
-- If login.html redirects you to init.jsp that means the system is still initializing. Wait a minute or two and try
-again.
-- If you are on mac and getting errors related to not finding jars when running com.articulate.sigma.KB, copy all jars
-from ~/workspace/sigmakee/build/lib/ to /Library/Java/Extensions
+See INSTALL.MacOS
 
 
 jUnit testing on the command line

--- a/build.xml
+++ b/build.xml
@@ -28,7 +28,7 @@
 
 <target name="compile" depends="init" description="Compile the project and place in ${build.classes}.">
     <mkdir dir="${build.classes}"/>
-    <javac destdir="${build.classes}" debug="on" optimize="on" deprecation="on" classpathref="compile.classpath">
+    <javac destdir="${build.classes}" debug="on" optimize="on" deprecation="on" includeantruntime="false" classpathref="compile.classpath">
         <src refid="core.sourcepath"/>
     </javac>
     <copy todir="${build.lib}">

--- a/config.xml
+++ b/config.xml
@@ -1,4 +1,4 @@
-<configuration >
+<configuration>
   <preference name="nlpTools" value="yes" />
   <preference name="sumokbname" value="SUMO" />
   <preference name="testOutputDir" value="~/.sigmakee/KBs/tests" />


### PR DESCRIPTION

1. solves #40 
2. adding a separated file with MacOS installation instructions. The MacOS installation puts all sigmakee and sumo files inside the `~/workspace`. 
3. change de readme.txt adding a reference to the INSTALL.MacOS

