### PR TITLE
Build vampire from git

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -127,6 +127,8 @@ jobs:
         with:
           context: .
           file: docker/sumo-ci/Dockerfile
+          build-args: |
+            IMAGE_ACCOUNT=${{ env.IMAGE_ACCOUNT }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ env.IMAGE_ACCOUNT }}/sumo-ci:latest
           cache-from: type=gha

--- a/docker/sigma-ci/Dockerfile
+++ b/docker/sigma-ci/Dockerfile
@@ -1,9 +1,12 @@
 FROM tomcat:9.0.73-jdk8-temurin-jammy as builder
 
+ARG VAMPIRE_GIT=c1643839b2a4e90057611837e018ad831c2da9fd
+
 RUN apt update; \
     apt-get install -y --no-install-recommends \
             build-essential \
             cmake \
+            git \
     ; \
     wget 'http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_2.6/E.tgz' &&\
     tar xf E.tgz ; \
@@ -12,15 +15,17 @@ RUN apt update; \
     cd .. ;\
     wget 'http://wordnetcode.princeton.edu/3.0/WordNet-3.0.tar.gz' ; \
     tar xf WordNet-3.0.tar.gz ; \
-    wget https://github.com/vprover/vampire/archive/refs/tags/snakeForV4.7+.tar.gz ; \
+    git clone --depth 1 https://github.com/vprover/vampire ; \
+    cd vampire ; \
+    git checkout $VAMPIRE_GIT ; \
+    cd .. ;\
     wget https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.12.1.tar.gz ; \
-    tar -xzf snakeForV4.7+.tar.gz ; \
     tar -xzf z3-4.12.1.tar.gz ; \
-    rm -rf vampire-snakeForV4.7-/z3 ; \
-    mv z3-z3-4.12.1 vampire-snakeForV4.7-/z3 ; \
-    mkdir vampire-snakeForV4.7-/z3/build ; \
-    mkdir vampire-snakeForV4.7-/build ; \
-    cd vampire-snakeForV4.7-/z3/build ; \
+    rm -rf vampire/z3 ; \
+    mv z3-z3-4.12.1 vampire/z3 ; \
+    mkdir vampire/z3/build ; \
+    mkdir vampire/build ; \
+    cd vampire/z3/build ; \
     cmake .. -DZ3_BUILD_EXECUTABLE=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF ; \
     make -j`nproc` ; \
     cd ../../build ; \
@@ -41,7 +46,7 @@ COPY --from=builder \
     /usr/local/tomcat/WordNet-3.0 /opt/WordNet-3.0
 
 COPY --from=builder \
-    /usr/local/tomcat/vampire-snakeForV4.7-/vampire /usr/local/bin/vampire
+    /usr/local/tomcat/vampire/vampire /usr/local/bin/vampire
 
 RUN apt update; \
     apt-get install -y --no-install-recommends \

--- a/docker/sumo-ci/Dockerfile
+++ b/docker/sumo-ci/Dockerfile
@@ -1,4 +1,5 @@
-FROM apease/sigma-ci:latest as builder
+ARG IMAGE_ACCOUNT=apease
+FROM $IMAGE_ACCOUNT/sigma-ci:latest as builder
 
 #################################################
 # runtime image.


### PR DESCRIPTION
Previously vampire in Docker images was built from the release last year.
This commit changes docker build files to build vampire from the git.
Controlled by
`
ARG VAMPIRE_GIT=c1643839b2a4e90057611837e018ad831c2da9fd`