### PR TITLE
Fix guard `SUMOKBtoTPTPKB`

### DIFF
--- a/src/java/com/articulate/sigma/trans/SUMOKBtoTPTPKB.java
+++ b/src/java/com/articulate/sigma/trans/SUMOKBtoTPTPKB.java
@@ -248,7 +248,7 @@ public class SUMOKBtoTPTPKB {
      */
     public void writeHeader(PrintWriter pw, String sanitizedKBName) {
 
-        if (pw == null) {
+        if (pw != null) {
             pw.println("% Articulate Software");
             pw.println("% www.ontologyportal.org www.articulatesoftware.com");
             pw.println("% This software released under the GNU Public License <http://www.gnu.org/copyleft/gpl.html>.");


### PR DESCRIPTION
Looks like a typo as current guard `pw == null` will never work. If `pw` is not null when it's guarded out.
But if `pw` is null it will pass the guard and fail with NPE at the next line