### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,14 @@ First, comply with System preparation on Linux above
 Clone SigmaKEE
 ```sh
 cd ~
+echo "export SIGMA_HOME=~/.sigmakee" >> .bashrc
+echo "export ONTOLOGYPORTAL_GIT=~/workspace" >> .bashrc
+echo "export SIGMA_SRC=$ONTOLOGYPORTAL_GIT/sigmakee" >> .bashrc
+echo "export CATALINA_OPTS=\"$CATALINA_OPTS -Xmx10g -Xss1m\"" >> .bashrc
+echo "export CATALINA_HOME=~/Programs/apache-tomcat-9.0.97" >> .bashrc
+echo "export PATH=$CATALINA_HOME/bin:$PATH" >> .bashrc
+echo "export SIGMA_CP=$SIGMA_SRC/build/sigmakee.jar:$SIGMA_SRC/lib/*" >> .bashrc
+source .bashrc
 mkdir workspace
 cd workspace
 git clone https://github.com/ontologyportal/sigmakee


### PR DESCRIPTION
New instructions fail if environment variables haven't been set in the .bashrc file.