### PR TITLE
Call sysctl -w kernel.perf_event_paranoid=-1 from Dockerfile

### DIFF
--- a/INSTALL.MacOS
+++ b/INSTALL.MacOS
@@ -66,6 +66,9 @@ Apache Tomcat.
   export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-23.jdk/Contents/Home
   export PATH=$JAVA_HOME/bin:$PATH
 
+cd ../workspace
+git clone https://github.com/ontologyportal/sigmakee
+
 Install (ensure the above preparations have been performed)
 > ant install
 

--- a/INSTALL.MacOS
+++ b/INSTALL.MacOS
@@ -66,7 +66,7 @@ Apache Tomcat.
   export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-23.jdk/Contents/Home
   export PATH=$JAVA_HOME/bin:$PATH
 
-cd ../workspace
+cd ~/workspace
 git clone https://github.com/ontologyportal/sigmakee
 
 Install (ensure the above preparations have been performed)

--- a/INSTALL.MacOS
+++ b/INSTALL.MacOS
@@ -66,7 +66,9 @@ Apache Tomcat.
   export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-23.jdk/Contents/Home
   export PATH=$JAVA_HOME/bin:$PATH
 
-cd ~/workspace
+cd ~
+mkdir workspace
+cd workspace
 git clone https://github.com/ontologyportal/sigmakee
 
 Install (ensure the above preparations have been performed)

--- a/build.xml
+++ b/build.xml
@@ -129,11 +129,9 @@
     <condition property="isUnixNotMac">
         <and>
             <os family="unix"/>
-
             <not>
                 <os family="mac"/>
             </not>
-
         </and>
     </condition>
 

--- a/docker/sigma-ci/Dockerfile
+++ b/docker/sigma-ci/Dockerfile
@@ -3,13 +3,11 @@ FROM tomcat:9.0.97-jdk21-temurin-jammy AS builder
 # Followed instructions from: https://github.com/vprover/vampire/wiki/Source-Build-for-Users
 # for buildling latest vampire w/ latest z3
 
-RUN apt update; \
-    apt-get install -y --no-install-recommends \
+RUN apt update && apt-get install -y --no-install-recommends \
             build-essential \
             cmake \
             git \
-            python3 \
-    ;\
+            python3 ;\
     wget 'http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_2.6/E.tgz' &&\
     tar xf E.tgz ;\
     cd E ;\

--- a/docker/sigma-ci/Dockerfile
+++ b/docker/sigma-ci/Dockerfile
@@ -3,11 +3,13 @@ FROM tomcat:9.0.97-jdk21-temurin-jammy AS builder
 # Followed instructions from: https://github.com/vprover/vampire/wiki/Source-Build-for-Users
 # for buildling latest vampire w/ latest z3
 
-RUN apt update && apt-get install -y --no-install-recommends \
+RUN apt update; \
+    apt-get install -y --no-install-recommends \
             build-essential \
             cmake \
             git \
-            python3 ;\
+            python3 \
+    ;\
     wget 'http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_2.6/E.tgz' &&\
     tar xf E.tgz ;\
     cd E ;\

--- a/docker/sigmakee/Dockerfile
+++ b/docker/sigmakee/Dockerfile
@@ -5,9 +5,15 @@ FROM $IMAGE_ACCOUNT/sigma-ci:latest AS builder
 # runtime image.
 FROM tomcat:9.0.97-jdk21-temurin-jammy AS runtime
 
-RUN apt update; \
-    apt-get install -y --no-install-recommends \
+# Switch to root user
+USER root
+
+RUN apt update && apt-get install -y --no-install-recommends \
+            sudo \
             graphviz
+
+# Set kernel parameter
+RUN sysctl -w kernel.perf_event_paranoid=-1
 
 COPY --from=builder \
     /usr/local/bin/e_ltb_runner /usr/local/bin/e_ltb_runner

--- a/docker/sumo-ci/Dockerfile
+++ b/docker/sumo-ci/Dockerfile
@@ -5,9 +5,15 @@ FROM $IMAGE_ACCOUNT/sigma-ci:latest AS builder
 # runtime image.
 FROM tomcat:9.0.97-jdk21-temurin-jammy AS runtime
 
-RUN apt update; \
-    apt-get install -y --no-install-recommends \
+# Switch to root user
+USER root
+
+RUN apt update && apt-get install -y --no-install-recommends \
+            sudo \
             graphviz
+
+# Set kernel parameter
+RUN sysctl -w kernel.perf_event_paranoid=-1
 
 COPY --from=builder \
     /usr/local/bin/e_ltb_runner /usr/local/bin/e_ltb_runner


### PR DESCRIPTION
This will hopefully get Vampire/z3 to run cleanly during the SUMO-CI workflow

Update README to include cloning SigmaKEE before running Ant install (thanks goes to Sam Pelham)