### PR TITLE
Update LinuxInstall.sh

### DIFF
--- a/LinuxInstall.sh
+++ b/LinuxInstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e  # Exit the script if any command returns a non-zero exit status
 
 echo "Installing Sigma"
 echo "Downloading prerequisites"
@@ -55,17 +56,24 @@ add_to_bashrc() {
     fi
 }
 
+# Set environment variables in the current shell and add them to .bashrc
+# NOTE: source ~/.bashrc doesn't seem to work in all cases.
+set_and_persist() {
+    local VAR_DECL="$1"
+    eval "$VAR_DECL" # Set the variable in the current environment
+    add_to_bashrc "$VAR_DECL" # Add the variable to .bashrc
+}
 
 # Add the necessary lines to .bashrc
 add_to_bashrc "alias dir='ls --color=auto --format=vertical -la'"
 add_to_bashrc "export HISTSIZE=10000 HISTFILESIZE=100000"
-add_to_bashrc "export SIGMA_HOME=\"\$HOME/.sigmakee\""
-add_to_bashrc "export ONTOLOGYPORTAL_GIT=\"\$HOME/workspace\""
-add_to_bashrc "export SIGMA_SRC=\"\$ONTOLOGYPORTAL_GIT/sigmakee\""
-add_to_bashrc "export CATALINA_OPTS=\"\$CATALINA_OPTS -Xmx10g -Xss1m\""
-add_to_bashrc "export CATALINA_HOME=\"\$HOME/Programs/apache-tomcat-9.0.97\""
-add_to_bashrc "export PATH=\"\$CATALINA_HOME/bin:\$PATH\""
-add_to_bashrc "export SIGMA_CP=\"\$SIGMA_SRC/build/sigmakee.jar:\$SIGMA_SRC/lib/*\""
+set_and_persist "export SIGMA_HOME=\"\$HOME/.sigmakee\""
+set_and_persist "export ONTOLOGYPORTAL_GIT=\"\$HOME/workspace\""
+set_and_persist "export SIGMA_SRC=\"\$ONTOLOGYPORTAL_GIT/sigmakee\""
+set_and_persist "export CATALINA_OPTS=\"\$CATALINA_OPTS -Xmx10g -Xss1m\""
+set_and_persist "export CATALINA_HOME=\"\$HOME/Programs/apache-tomcat-9.0.97\""
+set_and_persist "export PATH=\"\$CATALINA_HOME/bin:\$PATH\""
+set_and_persist "export SIGMA_CP=\"\$SIGMA_SRC/build/sigmakee.jar:\$SIGMA_SRC/lib/*\""
 
 # Source the .bashrc file to apply changes
 echo "Sourcing .bashrc to apply changes..."
@@ -89,6 +97,8 @@ else
 fi
 cd "$HOME/workspace"
 
+
+
 # Clone or update repositories
 REPOS=(
     "https://github.com/ontologyportal/sigmakee"
@@ -103,17 +113,39 @@ for REPO in "${REPOS[@]}"; do
         echo "Cloning $REPO..."
         git clone "$REPO"
     else
-        echo "$DIR_NAME repository already exists. Pulling the latest changes..."
-        cd "$HOME/workspace/$DIR_NAME"
-        git pull
-        cd "$HOME/workspace"
+        if [ -d "$HOME/workspace/$DIR_NAME" ]; then
+            echo "$DIR_NAME repository already exists. Pulling the latest changes..."
+            cd "$HOME/workspace/$DIR_NAME"
+            git pull
+            cd "$HOME/workspace"
+        else
+            echo "The folder $HOME/workspace/$DIR_NAME exists, but no Git repository found. Unable to do git pull. This probably means that a prior installation failed and wasn't completely cleaned up, in which case, the recommendation is deleting the $DIR_NAME folder and trying the install again. This script is exiting, to ensure nothing is deleted undesirably."
+            exit 1
+        fi
     fi
 done
+
+# Run the VerifyInstallationPrerequisites.sh script and print its output to the screen
+output=$(source $SIGMA_SRC/VerifyInstallationPrerequisites.sh | tee /dev/tty)
+
+# Check if the output contains "MISSING PREREQUISITES"
+if echo "$output" | grep -q "MISSING PREREQUISITES"; then
+  echo "Error: Missing prerequisites detected. Exiting script."
+  exit 1
+fi
+echo "All prerequisites met. Proceeding with the script."
+
 
 # Navigate to the sigmakee directory and run ant commands
 cd "$HOME/workspace/sigmakee"
 echo "Running ant install..."
-output=$(ant install 2>&1 | tee /dev/tty)
+output=$(env SIGMA_HOME="$SIGMA_HOME" \
+             ONTOLOGYPORTAL_GIT="$ONTOLOGYPORTAL_GIT" \
+             SIGMA_SRC="$SIGMA_SRC" \
+             CATALINA_OPTS="$CATALINA_OPTS" \
+             CATALINA_HOME="$CATALINA_HOME" \
+             SIGMA_CP="$SIGMA_CP" \
+             ant install 2>&1 | tee /dev/tty)
 if echo "$output" | grep -q "BUILD FAILED"; then
     echo "BUILD FAILED detected. Exiting the script."
     exit 1
@@ -122,7 +154,13 @@ else
 fi
 
 echo "Running ant to compile..."
-output=$(ant 2>&1 | tee /dev/tty)
+output=$(env SIGMA_HOME="$SIGMA_HOME" \
+             ONTOLOGYPORTAL_GIT="$ONTOLOGYPORTAL_GIT" \
+             SIGMA_SRC="$SIGMA_SRC" \
+             CATALINA_OPTS="$CATALINA_OPTS" \
+             CATALINA_HOME="$CATALINA_HOME" \
+             SIGMA_CP="$SIGMA_CP" \
+             ant 2>&1 | tee /dev/tty)
 if echo "$output" | grep -q "BUILD FAILED"; then
     echo "BUILD FAILED detected. Exiting the script."
     exit 1
@@ -130,7 +168,8 @@ else
     echo "Ant sigmakee compile completed successfully."
 fi
 
-echo "SIGMA has been installed! To start the server:"
+echo "\n\nSIGMA has been installed! Close and re-open your command line interface (or run 'source ~/.bashrc')."
+echo "To start the server:"
 echo "startup.sh"
 echo "Then point your browser to: http://localhost:8080/sigma/login.html"
 echo "username: admin     password: admin"


### PR DESCRIPTION
Integrated pre-requisite checker. 
No longer need to run with "source LinuxInstall.sh", as environment variables are passed to ant script. Exits on error.