### PR TITLE
Add another of the E prover binaries to SIGMA-CI

### DIFF
--- a/docker/sigma-ci/Dockerfile
+++ b/docker/sigma-ci/Dockerfile
@@ -87,6 +87,8 @@ COPY --from=builder \
     /E/PROVER/e_ltb_runner /usr/local/bin/e_ltb_runner
 COPY --from=builder \
     /E/PROVER/eprover /usr/local/bin/eprover
+COPY --from=builder \
+    /E/PROVER/epclextract /usr/local/bin/epclextract
 
 COPY --from=builder \
     /WordNet-3.0 /opt/WordNet-3.0


### PR DESCRIPTION
According to the EProver manual that comes with the source to build E:
A typical command line for starting e ltb runner is:
e_ltb_runner <batchspec> [path_to_eprover path_to_epclextract]