### PR TITLE
[Simon] Launching Stalll Fix Completed (Yesterday's fix was incomplete)

### DIFF
--- a/src/java/com/articulate/sigma/KButilities.java
+++ b/src/java/com/articulate/sigma/KButilities.java
@@ -50,16 +50,10 @@ import org.json.simple.JSONValue;
 @WebListener
 public class KButilities implements ServletContextListener {
 
-    /** Uses a fixed pool, which is more predictable and avoids deadlocks;
-    thread count can be changed by passing a system property:
-    java -Dsigma.exec.parallelism=6 ...
-    */
-    private static final int PAR = Integer.getInteger("sigma.exec.parallelism", 6);
-//    public static final ExecutorService EXECUTOR_SERVICE =
-//        Executors.newFixedThreadPool(PAR);
-    public static final ExecutorService EXECUTOR_SERVICE =
-        Executors.newWorkStealingPool();
-
+    /** Single-threadding used to address launch stall arity check*/
+    private static final int PAR = Integer.getInteger("sigma.exec.parallelism", 1);
+        public static final ExecutorService EXECUTOR_SERVICE =
+            Executors.newFixedThreadPool(PAR);
 
     /** A thread local pool for the Kryo serializer */
     public static final ThreadLocal<Kryo> kryoLocal = ThreadLocal.withInitial(() -> {


### PR DESCRIPTION
The last committ to SUMOjEdit provided an incomplete fix becasue only the ForkJoinPool system property was set, but the code wasn't actually using the common ForkJoinPool; it was creating its own pool that ignored those settings.

In other words, despite setting the ForkJoinPool system property to limit parallelism to 1, the system was still spawning 8 worker threads, for 2 reasons: 
1. The KButilities.EXECUTOR_SERVICE uses Executors.newWorkStealingPool() which creates its own ForkJoinPool that ignores the system property settings.
2. The threaded arity check (_t_checkArity()) submits many tasks to this pool, causing thread contention and deadlock.

###

The Fix: Changes in KButilities.java:

1. Changed default parallelism from 6 to 1
2. Switched from newWorkStealingPool() to newFixedThreadPool(PAR)
3. This forces all async operations to use exactly 1 thread, preventing the deadlock
