### PR TITLE
 * THREADING RACE CONDITION FIX - September 4, 2025

### DIFF
--- a/src/java/com/articulate/sigma/KButilities.java
+++ b/src/java/com/articulate/sigma/KButilities.java
@@ -31,9 +31,14 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,11 +55,116 @@ import org.json.simple.JSONValue;
 @WebListener
 public class KButilities implements ServletContextListener {
 
-    /** Single-threadding used to address launch stall arity check*/
     private static final int PAR = Integer.getInteger("sigma.exec.parallelism", 1);
-        public static final ExecutorService EXECUTOR_SERVICE =
-            Executors.newFixedThreadPool(PAR);
+    private static volatile ExecutorService currentExecutorService;
+    private static final Object executorLock = new Object();
+    private static volatile boolean isJEditMode = false;
 
+    // Create the appropriate ExecutorService based on context
+    private static ExecutorService createExecutorService() {
+        // Check if we're in single-threaded mode (jEdit context)
+        String parallelism = System.getProperty("java.util.concurrent.ForkJoinPool.common.parallelism");
+        isJEditMode = "1".equals(parallelism);
+        
+        if (isJEditMode) {
+            // For jEdit: use single-threaded executor to prevent deadlocks
+            System.out.println("KBUtilities: Creating single-threaded executor for jEdit mode");
+            return Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "SIGMA-jEdit-Thread");
+                t.setDaemon(false); // Don't make it daemon to ensure completion
+                return t;
+            });
+        } else {
+            // For translation: use fixed thread pool for predictable performance
+            System.out.println("KBUtilities: Creating fixed thread pool (" + PAR + " threads) for translation mode");
+            return Executors.newFixedThreadPool(PAR, r -> {
+                Thread t = new Thread(r, "SIGMA-Translation-Thread");
+                t.setDaemon(false);
+                return t;
+            });
+        }
+    }
+
+    // Lazy initialization with context detection
+    public static ExecutorService getExecutorService() {
+        if (currentExecutorService == null || currentExecutorService.isShutdown()) {
+            synchronized (executorLock) {
+                if (currentExecutorService == null || currentExecutorService.isShutdown()) {
+                    currentExecutorService = createExecutorService();
+                }
+            }
+        }
+        return currentExecutorService;
+    }
+
+    // Public property for backwards compatibility
+    public static final ExecutorService EXECUTOR_SERVICE = new ExecutorService() {
+        @Override
+        public void shutdown() {
+            getExecutorService().shutdown();
+        }
+        
+        @Override
+        public List<Runnable> shutdownNow() {
+            return getExecutorService().shutdownNow();
+        }
+        
+        @Override
+        public boolean isShutdown() {
+            return getExecutorService().isShutdown();
+        }
+        
+        @Override
+        public boolean isTerminated() {
+            return getExecutorService().isTerminated();
+        }
+        
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return getExecutorService().awaitTermination(timeout, unit);
+        }
+        
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            return getExecutorService().submit(task);
+        }
+        
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            return getExecutorService().submit(task, result);
+        }
+        
+        @Override
+        public Future<?> submit(Runnable task) {
+            return getExecutorService().submit(task);
+        }
+        
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+            return getExecutorService().invokeAll(tasks);
+        }
+        
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+            return getExecutorService().invokeAll(tasks, timeout, unit);
+        }
+        
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+            return getExecutorService().invokeAny(tasks);
+        }
+        
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return getExecutorService().invokeAny(tasks, timeout, unit);
+        }
+        
+        @Override
+        public void execute(Runnable command) {
+            getExecutorService().execute(command);
+        }
+    };
+    
     /** A thread local pool for the Kryo serializer */
     public static final ThreadLocal<Kryo> kryoLocal = ThreadLocal.withInitial(() -> {
         Kryo kryo = new Kryo();
@@ -97,6 +207,26 @@ public class KButilities implements ServletContextListener {
                 try {
                     kb.eprover.terminate();
                 } catch (IOException ex) {}
+    }
+
+    /** ***************************************************************
+     * Force a refresh of the ExecutorService - useful when switching contexts
+     */
+    public static void refreshExecutorService() {
+        synchronized (executorLock) {
+            if (currentExecutorService != null && !currentExecutorService.isShutdown()) {
+                try {
+                    currentExecutorService.shutdown();
+                    if (!currentExecutorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                        currentExecutorService.shutdownNow();
+                    }
+                } catch (InterruptedException e) {
+                    currentExecutorService.shutdownNow();
+                    Thread.currentThread().interrupt();
+                }
+            }
+            currentExecutorService = null; // Will be recreated on next access
+        }
     }
 
     /** *************************************************************
@@ -1479,15 +1609,32 @@ public class KButilities implements ServletContextListener {
      * of any main class where the executor is invoked.
      */
     public static void shutDownExecutorService() {
-        EXECUTOR_SERVICE.shutdown();
-        try {
-            if (!EXECUTOR_SERVICE.awaitTermination(10, TimeUnit.SECONDS)) {
-                EXECUTOR_SERVICE.shutdownNow();
+        synchronized (executorLock) {
+            if (currentExecutorService != null) {
+                System.out.println("KBUtilities.shutDownExecutorService(): Initiating executor shutdown");
+                currentExecutorService.shutdown();
+                try {
+                    // Give translation processes more time to complete
+                    int timeoutSeconds = isJEditMode ? 10 : 60;
+                    if (!currentExecutorService.awaitTermination(timeoutSeconds, TimeUnit.SECONDS)) {
+                        System.out.println("KBUtilities.shutDownExecutorService(): Forcing immediate shutdown");
+                        List<Runnable> unfinishedTasks = currentExecutorService.shutdownNow();
+                        System.out.println("KBUtilities.shutDownExecutorService(): " + unfinishedTasks.size() + " tasks were cancelled");
+                        
+                        // Give forceful shutdown a moment to complete
+                        if (!currentExecutorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                            System.err.println("KBUtilities.shutDownExecutorService(): ExecutorService did not terminate cleanly");
+                        }
+                    }
+                    System.out.println("KBUtilities.shutDownExecutorService(): ExecutorService shutdown complete");
+                } catch (InterruptedException e) {
+                    System.out.println("KBUtilities.shutDownExecutorService(): Shutdown interrupted, forcing immediate termination");
+                    currentExecutorService.shutdownNow();
+                    Thread.currentThread().interrupt();
+                }
+                currentExecutorService = null;
             }
-        } catch (InterruptedException e) {
-            EXECUTOR_SERVICE.shutdownNow();
         }
-//        System.out.println("KButilities.shutDownExecutorService(): ExecutorService shutdown");
     }
 
     /** ***************************************************************


### PR DESCRIPTION
[Simon] 
* ================================================= *
 * PROBLEM IDENTIFIED:
 * - jEdit launch required single-threaded mode (ForkJoinPool.common.parallelism=1)
 *   to prevent arity check deadlocks
 * - SUO-KIF to TPTP translation required multi-threading for efficient processing
 *   of thousands of formulas
 * - The WorkStealingPool in KBUtilities.EXECUTOR_SERVICE didn't respect
 *   single-threading constraints
 * - Result: Either jEdit would launch successfully OR translation would complete,
 *   but never both - a classic race condition
 *
 * ROOT CAUSE:
 * - Conflicting threading requirements between two processes sharing same ExecutorService
 * - No timeout mechanisms to prevent infinite hangs during translation
 * - WorkStealingPool ignored system property constraints
 *
 * SOLUTION IMPLEMENTED:
 *
 * 1. CONTEXT-AWARE EXECUTOR SERVICE (KBUtilities.java):
 *    - Dynamic ExecutorService creation based on detected context
 *    - Single-threaded executor when ForkJoinPool.common.parallelism=1 (jEdit mode)
 *    - Fixed thread pool for translation processes
 *    - Added refreshExecutorService() method to switch contexts
 *    - Enhanced shutdown with longer timeouts for translation processes
 *
 * 2. ENHANCED TRANSLATION PROCESS (SUMOKBtoTPTPKB.java):
 *    - Added timeout handling (30-minute timeout per task)
 *    - Improved progress monitoring and error reporting
 *    - Graceful failure handling - continues even if some tasks fail
 *    - Better resource cleanup to prevent memory leaks
 *
 * 3. COORDINATED JEDIT INTEGRATION (SUMOjEdit.java):
 *    - Calls KBUtilities.refreshExecutorService() after setting single-threaded mode
 *    - Proper cleanup method for resource management
 *    - Better error handling during KB initialization
 *
 * 4. TRANSLATION COMMAND ENHANCEMENT (KB.main()):
 *    - Clears single-threaded mode before translation
 *    - Refreshes ExecutorService for translation-optimized threading
 *    - Added try-finally block to ensure ExecutorService always shuts down
 *    - Proper cleanup prevents resource leaks
 *
 * 5. IMPORT FIX (SUMOjEdit.java):
 *    - Fixed View import conflict: javax.swing.text.View vs org.gjt.sp.jedit.View
 *    - Ensured proper jEdit View type is used throughout
 *