### PR TITLE
[Simon] Threading Setting Changed

### DIFF
--- a/src/java/com/articulate/sigma/KButilities.java
+++ b/src/java/com/articulate/sigma/KButilities.java
@@ -61,9 +61,17 @@ public class KButilities implements ServletContextListener {
 
     // Create the appropriate ExecutorService based on context
     private static ExecutorService createExecutorService() {
-        // Check if we're in single-threaded mode (jEdit context)
-        String parallelism = System.getProperty("java.util.concurrent.ForkJoinPool.common.parallelism");
-        isJEditMode = "1".equals(parallelism);
+        // Prefer explicit sigma.exec.mode; fallback to legacy ForkJoinPool property
+        String mode = System.getProperty("sigma.exec.mode"); // "jedit-single" or "parallel"
+        if ("jedit-single".equalsIgnoreCase(mode)) {
+            isJEditMode = true;
+        } else if ("parallel".equalsIgnoreCase(mode)) {
+            isJEditMode = false;
+        } else {
+            // Legacy behavior for backward-compatibility
+            String parallelism = System.getProperty("java.util.concurrent.ForkJoinPool.common.parallelism");
+            isJEditMode = "1".equals(parallelism);
+        }
 
         if (isJEditMode) {
             // For jEdit: use single-threaded executor to prevent deadlocks


### PR DESCRIPTION
Today we made KButilities pick its executor mode explicitly, not implicitly. We introduced a new switch—sigma.exec.mode—that accepts jedit-single (force a single-thread executor for safe jEdit bootstrap) or parallel (use a fixed thread pool). For backward compatibility, if that property isn’t set we fall back to the old check of java.util.concurrent.ForkJoinPool.common.parallelism == "1". The pool size for parallel mode remains tunable via sigma.exec.parallelism (defaulting to availableProcessors()), and refreshExecutorService() now rebuilds the executor whenever the mode flips. Net effect: no more surprising coupling to the JVM’s global ForkJoinPool knob, clear logs about which pool is created, and predictable, controllable concurrency for the checker.