### PR TITLE
[Simon] Fixed a trailing space error in config.xml

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -73,7 +73,7 @@
     <constituent filename="MilitaryPersons.kif" />
     <constituent filename="MilitaryProcesses.kif" />
     <constituent filename="Music.kif" />
-    <constituent filename="development/Muscles.kif " />
+    <constituent filename="development/Muscles.kif" />
     <constituent filename="naics.kif" />
     <constituent filename="People.kif" />
     <constituent filename="pictureList.kif" />


### PR DESCRIPTION
The trailing space in <constituent filename="development/Muscles.kif " /> has been removed to ensure proper file referencing and avoid potential issues with file paths, such as "file not found" errors.