### PR TITLE
[Simon] Fixed Unit Test config path rewriting on macOS; New Unit Test Created for LeoExecutable (in config.xml)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -177,11 +177,27 @@
     ============
     -->
 
-    <!-- Replace 'theuser' placeholder in test config XMLs with the actual username -->
+    <!-- Replace placeholders in test config XMLs with portable paths for the current machine -->
     <target name="prepare.test.configs" depends="init"
-            description="Update test config XML files with the current user name.">
+            description="Update test config XML files with the current user name and home directory.">
         <echo message="Updating test config XML files for user ${user.name} (home: ${user.home})"/>
-        <!-- Simple version: just swap 'theuser' -> ${user.name} -->
+
+        <!-- 1) Make home path portable (macOS: /Users/..., Linux: /home/...) -->
+        <replace token="/home/theuser" value="${user.home}">
+            <fileset dir="${basedir}">
+                <!-- Integration test configs -->
+                <include name="test/integration/java/resources/config_all.xml"/>
+                <include name="test/integration/java/resources/config_topAndMid.xml"/>
+                <include name="test/integration/java/resources/config_topOnly.xml"/>
+
+                <!-- Unit test configs -->
+                <include name="test/unit/java/resources/config_all.xml"/>
+                <include name="test/unit/java/resources/config_topAndMid.xml"/>
+                <include name="test/unit/java/resources/config_topOnly.xml"/>
+            </fileset>
+        </replace>
+
+        <!-- 2) Replace remaining username placeholder -->
         <replace token="theuser" value="${user.name}">
             <fileset dir="${basedir}">
                 <!-- Integration test configs -->

--- a/test/unit/java/com/articulate/sigma/LeoExecutableConfigTest.java
+++ b/test/unit/java/com/articulate/sigma/LeoExecutableConfigTest.java
@@ -1,0 +1,46 @@
+package com.articulate.sigma;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class LeoExecutableConfigTest extends UnitTestBase {
+
+    /**
+     * Verifies that the leoExecutable preference points to a real executable.
+     *
+     * This is an opt-in local integration test because config.xml lives under
+     * ~/.sigmakee (or equivalent) and differs per machine/OS.
+     *
+     * Enable by setting: RUN_EXTERNAL_ATP_TESTS=true
+     * 
+     * 
+     * Author: Simon Deng, NPS ORISE Intern 2025, adam.pease@nps.edu
+     * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.FormatSuoKifAxiomsGUITest">Simon Deng, NPS ORISE Intern 2025</a>
+     */
+    
+    @Test
+    public void testLeoExecutablePrefIsValidExecutable() {
+
+        // Skip by default (so CI doesn't fail on machines without LEO installed)
+        Assume.assumeTrue(
+                "Set RUN_EXTERNAL_ATP_TESTS=true to enable external ATP configuration checks",
+                "true".equalsIgnoreCase(System.getenv("RUN_EXTERNAL_ATP_TESTS"))
+        );
+
+        KBmanager.getMgr().initializeOnce();
+
+        String leoPath = KBmanager.getMgr().getPref("leoExecutable");
+        assertNotNull("leoExecutable pref must not be null", leoPath);
+        assertFalse("leoExecutable pref must not be empty", leoPath.trim().isEmpty());
+
+        File exe = new File(leoPath);
+
+        assertTrue("leoExecutable does not exist: " + leoPath, exe.exists());
+        assertTrue("leoExecutable is not a file: " + leoPath, exe.isFile());
+        assertTrue("leoExecutable is not executable: " + leoPath, exe.canExecute());
+    }
+}

--- a/test/unit/java/com/articulate/sigma/UnitSigmaTestSuite.java
+++ b/test/unit/java/com/articulate/sigma/UnitSigmaTestSuite.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite;
     KBcacheUnitTest.class,
     KIFTest.class,
     KifFileCheckerTest.class,
+    LeoExecutableConfigTest.class,
     // TPTPFileCheckerTest.class,
     KButilitiesTest.class,
     KBmanagerInitTest.class,


### PR DESCRIPTION
1. Updated prepare.test.configs in build.xml to replace /home/theuser with ${user.home} before substituting the username, ensuring test config paths resolve correctly on macOS and preventing /home/<user> path errors during ant test.unit.

2. Also added LeoExecutableConfigTest.java to verify LeoExecutable Config handles config paths properly across different OS environments.