### PR TITLE
Add config mode switcher for full/fast KB loading

### DIFF
--- a/docs/sigma-config-README.md
+++ b/docs/sigma-config-README.md
@@ -1,0 +1,197 @@
+# sigma-config.sh - KB Configuration Mode Switcher
+
+## The Problem
+
+When developing SUMO ontology extensions, you face a trade-off:
+
+| Mode | Pros | Cons |
+|------|------|------|
+| **Full KB** | All terms available in jEdit/VSCode autocomplete, complete type checking | Vampire/E-Prover queries timeout or take minutes |
+| **Minimal KB** | Fast inference (seconds) | Missing terms, limited autocomplete, incomplete type checking |
+
+Manually editing `config.xml` to switch between these modes is tedious and error-prone.
+
+## The Solution
+
+`sigma-config.sh` lets you instantly switch between full and fast configurations:
+
+```bash
+./sigma-config.sh full    # For coding/browsing (all terms)
+./sigma-config.sh fast    # For inference testing (quick queries)
+./sigma-config.sh status  # Check current mode
+```
+
+## Installation
+
+The script is included in the SigmaKEE repository. For convenience, add it to your PATH:
+
+```bash
+# Add to ~/.bashrc
+export PATH="$ONTOLOGYPORTAL_GIT/sigmakee:$PATH"
+
+# Or create a symlink
+ln -s ~/workspace/sigmakee/sigma-config.sh ~/bin/sigma-config
+```
+
+## Example Workflows
+
+### Workflow 1: Developing New Ontology Terms
+
+This workflow is for writing new .kif files with full term coverage.
+
+```bash
+# 1. Start in FULL mode for coding
+sigma-config.sh full
+
+# 2. Launch jEdit with full term support
+jedit ~/.sigmakee/KBs/my-ontology.kif
+
+# 3. Write your axioms with full autocomplete and type checking
+#    - All SUMO terms available
+#    - Ctrl+Space for completion
+#    - Plugins → SUMOjEdit → Check for SUO-KIF errors
+
+# 4. When ready to test inference, switch to FAST mode
+sigma-config.sh fast
+
+# 5. Restart jEdit to reload minimal KB
+#    (or use Plugins → SUMOjEdit → Reload KB)
+
+# 6. Test your specific axiom
+#    - Highlight the axiom
+#    - Plugins → SUMOjEdit → Query on highlighted expression
+#    - Results appear quickly (seconds, not minutes)
+
+# 7. Switch back to FULL mode to continue coding
+sigma-config.sh full
+```
+
+### Workflow 2: Quick Inference Testing Loop
+
+This workflow is for rapidly iterating on axiom correctness.
+
+```bash
+# 1. Start in FAST mode
+sigma-config.sh fast
+
+# 2. Edit your .kif file (any editor works)
+code ~/.sigmakee/KBs/my-ontology.kif
+
+# 3. Test via command line (no jEdit needed)
+cd ~/workspace/sigmakee
+java -Xmx10g -Xss1m -cp "build/sigmakee.jar:lib/*" \
+    com.articulate.sigma.KB v --ask "(your-query-here)" --timeout 30
+
+# 4. Iterate: edit → save → run query → repeat
+```
+
+### Workflow 3: Contributing to SUMO
+
+This workflow is for submitting ontology changes upstream.
+
+```bash
+# 1. Fork and clone the sumo repository
+cd ~/workspace
+git clone https://github.com/YOUR_USERNAME/sumo.git sumo-fork
+cd sumo-fork
+git remote add upstream https://github.com/ontologyportal/sumo.git
+
+# 2. Create a feature branch
+git checkout -b feature/add-cybersecurity-terms
+
+# 3. Switch to FULL mode for development
+sigma-config.sh full
+jedit your-new-ontology.kif
+
+# 4. Develop with full term support...
+
+# 5. Before committing, validate your axioms:
+
+#    a. Syntax check (FULL mode)
+#       - Load in Sigma browser or jEdit
+#       - Check for parse errors
+
+#    b. Inference check (FAST mode)
+sigma-config.sh fast
+#       - Add your .kif to config-fast.xml temporarily:
+#         <constituent filename="your-new-ontology.kif" />
+#       - Run targeted queries to verify axioms
+
+# 6. Run the test suite
+cd ~/workspace/sigmakee
+ant test
+
+# 7. Commit and push
+git add your-new-ontology.kif
+git commit -m "Add cybersecurity domain terms"
+git push origin feature/add-cybersecurity-terms
+
+# 8. Open a Pull Request on GitHub
+```
+
+### Workflow 4: Customizing Fast Mode
+
+By default, fast mode only loads `Merge.kif`. You can customize it:
+
+```bash
+# 1. Initialize config files
+sigma-config.sh init
+
+# 2. Edit the fast config to include your files
+nano ~/.sigmakee/KBs/config-fast.xml
+
+# Add your ontology file:
+#   <kb name="SUMO" >
+#     <constituent filename="Merge.kif" />
+#     <constituent filename="my-ontology.kif" />
+#   </kb>
+
+# 3. Now fast mode includes your terms
+sigma-config.sh fast
+```
+
+## Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `sigma-config.sh full` | Switch to full KB (all ontology files) |
+| `sigma-config.sh fast` | Switch to minimal KB (Merge.kif only) |
+| `sigma-config.sh status` | Show current mode and config file locations |
+| `sigma-config.sh init` | Create config-full.xml and config-fast.xml |
+| `sigma-config.sh --help` | Show help message |
+
+## Config Files
+
+After running `init`, you'll have:
+
+| File | Purpose |
+|------|---------|
+| `~/.sigmakee/KBs/config.xml` | Active configuration (what Sigma/jEdit loads) |
+| `~/.sigmakee/KBs/config-full.xml` | Full KB template |
+| `~/.sigmakee/KBs/config-fast.xml` | Minimal KB template |
+
+## Tips
+
+1. **Always restart jEdit/Sigma after switching modes** — the KB is loaded at startup
+
+2. **Customize config-fast.xml** — add your working ontology files so they're available in fast mode
+
+3. **Use fast mode for CI/testing** — queries complete in seconds instead of timing out
+
+4. **Check mode before long operations** — run `sigma-config.sh status` to avoid surprises
+
+## Troubleshooting
+
+**"Config file not found"**
+- Run `ant install` first to set up SigmaKEE
+- Or run `sigma-config.sh init` after creating a config.xml manually
+
+**"Terms missing in jEdit"**
+- You're probably in fast mode: `sigma-config.sh status`
+- Switch to full: `sigma-config.sh full`
+- Restart jEdit
+
+**"Vampire queries timeout"**
+- You're probably in full mode with too many axioms
+- Switch to fast: `sigma-config.sh fast`
+- Or increase timeout: `--timeout 120`

--- a/sigma-config.sh
+++ b/sigma-config.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# sigma-config.sh - Switch between full and fast SigmaKEE KB configurations
+#
+# Problem: Loading the full SUMO ontology (all .kif files) provides complete
+# term coverage for browsing and coding in jEdit/VSCode, but makes Vampire
+# inference queries very slow or timeout. Loading only Merge.kif makes
+# inference fast but limits available terms.
+#
+# Solution: This script allows quick switching between two config modes:
+#   - full: All KB files loaded (for jEdit browsing, coding, term lookup)
+#   - fast: Minimal KB files (for quick Vampire/E-Prover inference testing)
+#
+# Usage:
+#   sigma-config.sh full    # Switch to full KB (coding mode)
+#   sigma-config.sh fast    # Switch to fast KB (inference mode)
+#   sigma-config.sh status  # Show current mode
+#   sigma-config.sh init    # Create initial config files if missing
+#
+# After switching, restart jEdit or Sigma to reload the KB.
+
+set -e
+
+# Determine SIGMA_HOME
+if [[ -z "$SIGMA_HOME" ]]; then
+    SIGMA_HOME="$HOME/.sigmakee"
+fi
+
+CONFIG_DIR="$SIGMA_HOME/KBs"
+CURRENT="$CONFIG_DIR/config.xml"
+FULL="$CONFIG_DIR/config-full.xml"
+FAST="$CONFIG_DIR/config-fast.xml"
+
+# Colors for output (if terminal supports it)
+if [[ -t 1 ]]; then
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m' # No Color
+else
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+usage() {
+    cat << EOF
+sigma-config.sh - Switch between full and fast SigmaKEE KB configurations
+
+Usage: $0 [command]
+
+Commands:
+  full    Switch to full KB mode (all ontology files for coding/browsing)
+  fast    Switch to fast KB mode (minimal files for quick inference)
+  status  Show current configuration mode (default if no command given)
+  init    Initialize config files (creates full and fast variants)
+
+After switching modes, restart jEdit or Sigma to reload the KB.
+
+Examples:
+  $0 full     # Load all terms for jEdit coding
+  $0 fast     # Quick Vampire testing with minimal KB
+  $0          # Check current mode
+
+EOF
+}
+
+detect_mode() {
+    if grep -q "Mid-level-ontology.kif" "$CURRENT" 2>/dev/null; then
+        echo "full"
+    else
+        echo "fast"
+    fi
+}
+
+init_configs() {
+    if [[ ! -f "$CURRENT" ]]; then
+        echo -e "${YELLOW}Error: No config.xml found at $CURRENT${NC}"
+        echo "Please run 'ant install' first to set up SigmaKEE."
+        exit 1
+    fi
+
+    # Create full config if missing
+    if [[ ! -f "$FULL" ]]; then
+        echo "Creating config-full.xml..."
+        cp "$CURRENT" "$FULL"
+    fi
+
+    # Create fast config if missing
+    if [[ ! -f "$FAST" ]]; then
+        echo "Creating config-fast.xml..."
+        # Start with current config and reduce to minimal KB
+        cp "$CURRENT" "$FAST"
+
+        # Replace the kb block with minimal constituents
+        # This is a simple approach - keeps Merge.kif only
+        sed -i '/<kb name="SUMO"/,/<\/kb>/c\
+  <kb name="SUMO" >\
+    <constituent filename="Merge.kif" />\
+  </kb>' "$FAST"
+    fi
+
+    echo -e "${GREEN}Config files initialized.${NC}"
+    echo "  Full config: $FULL"
+    echo "  Fast config: $FAST"
+}
+
+switch_full() {
+    if [[ ! -f "$FULL" ]]; then
+        echo -e "${YELLOW}Full config not found. Running init...${NC}"
+        init_configs
+    fi
+
+    cp "$FULL" "$CURRENT"
+    echo -e "${GREEN}Switched to FULL config mode${NC}"
+    echo ""
+    echo "  Mode: Full KB (coding/browsing)"
+    echo "  - All ontology files loaded"
+    echo "  - Complete term coverage for jEdit/VSCode"
+    echo "  - Inference queries may be slow"
+    echo ""
+    echo -e "${BLUE}Restart jEdit or Sigma to reload the KB.${NC}"
+}
+
+switch_fast() {
+    if [[ ! -f "$FAST" ]]; then
+        echo -e "${YELLOW}Fast config not found. Running init...${NC}"
+        init_configs
+    fi
+
+    cp "$FAST" "$CURRENT"
+    echo -e "${GREEN}Switched to FAST config mode${NC}"
+    echo ""
+    echo "  Mode: Minimal KB (inference testing)"
+    echo "  - Only Merge.kif loaded"
+    echo "  - Fast Vampire/E-Prover queries"
+    echo "  - Limited terms available"
+    echo ""
+    echo -e "${BLUE}Restart jEdit or Sigma to reload the KB.${NC}"
+}
+
+show_status() {
+    local mode=$(detect_mode)
+    echo -e "Current mode: ${GREEN}$mode${NC}"
+    echo ""
+    echo "Config files:"
+    echo "  Current: $CURRENT"
+    [[ -f "$FULL" ]] && echo "  Full:    $FULL" || echo "  Full:    (not created)"
+    [[ -f "$FAST" ]] && echo "  Fast:    $FAST" || echo "  Fast:    (not created)"
+    echo ""
+    echo "Use '$0 full' or '$0 fast' to switch modes."
+}
+
+# Main
+case "${1:-status}" in
+    full)
+        switch_full
+        ;;
+    fast)
+        switch_fast
+        ;;
+    status)
+        show_status
+        ;;
+    init)
+        init_configs
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        echo "Unknown command: $1"
+        echo ""
+        usage
+        exit 1
+        ;;
+esac

--- a/test/scripts/sigma-config-test.sh
+++ b/test/scripts/sigma-config-test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# sigma-config-test.sh - Unit tests for sigma-config.sh
+#
+# Run with: ./test/scripts/sigma-config-test.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SIGMA_CONFIG="$REPO_ROOT/sigma-config.sh"
+
+# Create temp directory for testing
+TEST_DIR=$(mktemp -d)
+export SIGMA_HOME="$TEST_DIR"
+mkdir -p "$TEST_DIR/KBs"
+
+# Track test results
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+cleanup() {
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+pass() {
+    ((TESTS_PASSED++))
+    echo -e "${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    ((TESTS_FAILED++))
+    echo -e "${RED}FAIL${NC}: $1"
+}
+
+run_test() {
+    ((TESTS_RUN++))
+    local test_name="$1"
+    shift
+    if "$@"; then
+        pass "$test_name"
+    else
+        fail "$test_name"
+    fi
+}
+
+# Create a minimal config.xml for testing
+create_test_config() {
+    cat > "$TEST_DIR/KBs/config.xml" << 'EOF'
+<configuration>
+  <preference name="baseDir" value="/test/.sigmakee" />
+  <kb name="SUMO" >
+    <constituent filename="Merge.kif" />
+    <constituent filename="Mid-level-ontology.kif" />
+  </kb>
+</configuration>
+EOF
+}
+
+# ============================================================
+# Test Cases
+# ============================================================
+
+test_script_exists() {
+    [[ -x "$SIGMA_CONFIG" ]]
+}
+
+test_help_works() {
+    "$SIGMA_CONFIG" --help >/dev/null 2>&1
+}
+
+test_status_without_config() {
+    rm -f "$TEST_DIR/KBs/config.xml"
+    # Should not crash, but may show error
+    "$SIGMA_CONFIG" status 2>&1 | grep -q "mode\|Error\|not found"
+}
+
+test_init_creates_configs() {
+    create_test_config
+    "$SIGMA_CONFIG" init >/dev/null 2>&1
+    [[ -f "$TEST_DIR/KBs/config-full.xml" ]] && [[ -f "$TEST_DIR/KBs/config-fast.xml" ]]
+}
+
+test_detect_full_mode() {
+    create_test_config
+    local output=$("$SIGMA_CONFIG" status 2>&1)
+    echo "$output" | grep -q "full"
+}
+
+test_switch_to_fast() {
+    create_test_config
+    "$SIGMA_CONFIG" init >/dev/null 2>&1
+    "$SIGMA_CONFIG" fast >/dev/null 2>&1
+    # Fast config should NOT have Mid-level-ontology.kif
+    ! grep -q "Mid-level-ontology.kif" "$TEST_DIR/KBs/config.xml"
+}
+
+test_switch_to_full() {
+    create_test_config
+    "$SIGMA_CONFIG" init >/dev/null 2>&1
+    "$SIGMA_CONFIG" fast >/dev/null 2>&1
+    "$SIGMA_CONFIG" full >/dev/null 2>&1
+    # Full config should have Mid-level-ontology.kif
+    grep -q "Mid-level-ontology.kif" "$TEST_DIR/KBs/config.xml"
+}
+
+test_fast_has_merge_kif() {
+    create_test_config
+    "$SIGMA_CONFIG" init >/dev/null 2>&1
+    "$SIGMA_CONFIG" fast >/dev/null 2>&1
+    # Fast config should still have Merge.kif
+    grep -q "Merge.kif" "$TEST_DIR/KBs/config.xml"
+}
+
+test_invalid_command() {
+    # Should exit with error for invalid command
+    ! "$SIGMA_CONFIG" invalid_command_xyz >/dev/null 2>&1
+}
+
+# ============================================================
+# Run Tests
+# ============================================================
+
+echo "Running sigma-config.sh unit tests..."
+echo "Test directory: $TEST_DIR"
+echo ""
+
+run_test "Script exists and is executable" test_script_exists
+run_test "Help command works" test_help_works
+run_test "Status handles missing config" test_status_without_config
+run_test "Init creates config files" test_init_creates_configs
+run_test "Detects full mode correctly" test_detect_full_mode
+run_test "Switch to fast mode" test_switch_to_fast
+run_test "Switch to full mode" test_switch_to_full
+run_test "Fast mode still has Merge.kif" test_fast_has_merge_kif
+run_test "Invalid command returns error" test_invalid_command
+
+echo ""
+echo "============================================================"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "${RED}$TESTS_FAILED tests failed${NC}"
+    exit 1
+else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi


### PR DESCRIPTION
Problem: Loading the full SUMO ontology provides complete term coverage for browsing and coding in jEdit/VSCode, but makes Vampire inference queries very slow or timeout. Loading only Merge.kif makes inference fast but limits available terms for development.

Solution: sigma-config.sh script that allows quick switching between:
- full: All KB files loaded (for jEdit browsing, coding, term lookup)
- fast: Minimal KB files (for quick Vampire/E-Prover inference testing)

Usage:
  sigma-config.sh full    # Switch to full KB (coding mode)
  sigma-config.sh fast    # Switch to fast KB (inference mode)
  sigma-config.sh status  # Show current mode
  sigma-config.sh init    # Create initial config files

Includes:
- Unit tests in test/scripts/sigma-config-test.sh
- Documentation with workflow examples in docs/sigma-config-README.md