### PR TITLE
Add add/remove/list commands to sigma-config.sh

### DIFF
--- a/sigma-config.sh
+++ b/sigma-config.sh
@@ -12,12 +12,14 @@
 #   - fast: Minimal KB files (for quick Vampire/E-Prover inference testing)
 #
 # Usage:
-#   sigma-config.sh full    # Switch to full KB (coding mode)
-#   sigma-config.sh fast    # Switch to fast KB (inference mode)
-#   sigma-config.sh status  # Show current mode
-#   sigma-config.sh init    # Create initial config files if missing
+#   sigma-config.sh full            # Switch to full KB (coding mode)
+#   sigma-config.sh fast            # Switch to fast KB (inference mode)
+#   sigma-config.sh add [file.kif]  # Add a .kif file to the current KB config
+#   sigma-config.sh remove [name]   # Remove a .kif file from the current KB config
+#   sigma-config.sh status          # Show current mode and loaded files
+#   sigma-config.sh init            # Create initial config files if missing
 #
-# After switching, restart jEdit or Sigma to reload the KB.
+# After switching or adding files, restart jEdit or Sigma to reload the KB.
 
 set -e
 
@@ -48,20 +50,27 @@ usage() {
     cat << EOF
 sigma-config.sh - Switch between full and fast SigmaKEE KB configurations
 
-Usage: $0 [command]
+Usage: $0 [command] [args]
 
 Commands:
-  full    Switch to full KB mode (all ontology files for coding/browsing)
-  fast    Switch to fast KB mode (minimal files for quick inference)
-  status  Show current configuration mode (default if no command given)
-  init    Initialize config files (creates full and fast variants)
+  full              Switch to full KB mode (all ontology files for coding/browsing)
+  fast              Switch to fast KB mode (minimal files for quick inference)
+  add [file.kif]    Add a dev .kif file to the KB (symlinks + adds to config)
+  remove [name]     Remove a .kif file from the KB config (and its symlink)
+  list              Show all constituent .kif files in the current config
+  status            Show current configuration mode (default if no command given)
+  init              Initialize config files (creates full and fast variants)
 
-After switching modes, restart jEdit or Sigma to reload the KB.
+After switching modes or adding/removing files, restart jEdit or Sigma to reload the KB.
 
 Examples:
-  $0 full     # Load all terms for jEdit coding
-  $0 fast     # Quick Vampire testing with minimal KB
-  $0          # Check current mode
+  $0 full                                         # Load all terms for jEdit coding
+  $0 fast                                         # Quick Vampire testing with minimal KB
+  $0 add ~/workspace/sumo/development/Cyber.kif   # Add your dev file to the KB
+  $0 add                                          # Interactive: prompts for file path
+  $0 remove Cyber.kif                             # Remove a file from the KB
+  $0 list                                         # Show what's currently loaded
+  $0                                              # Check current mode
 
 EOF
 }
@@ -140,6 +149,137 @@ switch_fast() {
     echo -e "${BLUE}Restart jEdit or Sigma to reload the KB.${NC}"
 }
 
+add_file() {
+    local filepath="$1"
+
+    # Interactive prompt if no file path provided
+    if [[ -z "$filepath" ]]; then
+        echo -e "${BLUE}Add a .kif file to the Sigma KB${NC}"
+        echo ""
+        echo "Enter the full path to the .kif file you are working on:"
+        echo "  (e.g., ~/workspace/sumo/development/Cyber.kif)"
+        echo ""
+        read -rp "> " filepath
+        echo ""
+    fi
+
+    # Expand ~ and resolve to absolute path
+    filepath="${filepath/#\~/$HOME}"
+    filepath="$(realpath "$filepath" 2>/dev/null || echo "$filepath")"
+
+    # Validate the file exists and is a .kif file
+    if [[ ! -f "$filepath" ]]; then
+        echo -e "${YELLOW}Error: File not found: $filepath${NC}"
+        exit 1
+    fi
+
+    if [[ "$filepath" != *.kif ]]; then
+        echo -e "${YELLOW}Error: File must be a .kif file: $filepath${NC}"
+        exit 1
+    fi
+
+    local basename
+    basename="$(basename "$filepath")"
+
+    # Check if already in config
+    if grep -q "\"$basename\"" "$CURRENT" 2>/dev/null; then
+        echo -e "${YELLOW}$basename is already in the current config.${NC}"
+
+        # Check if symlink exists
+        if [[ -L "$CONFIG_DIR/$basename" ]]; then
+            echo "  Symlink: $CONFIG_DIR/$basename -> $(readlink "$CONFIG_DIR/$basename")"
+        elif [[ -f "$CONFIG_DIR/$basename" ]]; then
+            echo "  File exists at: $CONFIG_DIR/$basename (not a symlink)"
+        fi
+        return 0
+    fi
+
+    # Create symlink into KBs directory (if file isn't already there)
+    if [[ "$(dirname "$filepath")" != "$CONFIG_DIR" ]]; then
+        if [[ -e "$CONFIG_DIR/$basename" ]]; then
+            echo -e "${YELLOW}Warning: $CONFIG_DIR/$basename already exists.${NC}"
+            read -rp "Overwrite with symlink to $filepath? [y/N] " confirm
+            if [[ "$confirm" != [yY] ]]; then
+                echo "Aborted."
+                exit 1
+            fi
+            rm "$CONFIG_DIR/$basename"
+        fi
+        ln -s "$filepath" "$CONFIG_DIR/$basename"
+        echo -e "  Symlink: ${GREEN}$CONFIG_DIR/$basename -> $filepath${NC}"
+    fi
+
+    # Add constituent line to config.xml (before </kb>)
+    sed -i "/<\/kb>/i\\    <constituent filename=\"$basename\" />" "$CURRENT"
+
+    # Also add to full and fast configs if they exist
+    if [[ -f "$FULL" ]] && ! grep -q "\"$basename\"" "$FULL"; then
+        sed -i "/<\/kb>/i\\    <constituent filename=\"$basename\" />" "$FULL"
+        echo "  Added to: config-full.xml"
+    fi
+    if [[ -f "$FAST" ]] && ! grep -q "\"$basename\"" "$FAST"; then
+        sed -i "/<\/kb>/i\\    <constituent filename=\"$basename\" />" "$FAST"
+        echo "  Added to: config-fast.xml"
+    fi
+
+    echo ""
+    echo -e "${GREEN}Added $basename to the KB configuration.${NC}"
+    echo -e "${BLUE}Restart jEdit or Sigma to reload the KB.${NC}"
+}
+
+remove_file() {
+    local name="$1"
+
+    if [[ -z "$name" ]]; then
+        echo "Usage: $0 remove <filename.kif>"
+        echo ""
+        echo "Currently loaded files:"
+        list_files
+        exit 1
+    fi
+
+    # Normalize: just the basename
+    name="$(basename "$name")"
+
+    # Protect core files from removal
+    case "$name" in
+        Merge.kif|english_format.kif|domainEnglishFormat.kif)
+            echo -e "${YELLOW}Error: Cannot remove core file $name${NC}"
+            exit 1
+            ;;
+    esac
+
+    if ! grep -q "\"$name\"" "$CURRENT" 2>/dev/null; then
+        echo -e "${YELLOW}$name is not in the current config.${NC}"
+        exit 1
+    fi
+
+    # Remove from all config files
+    sed -i "/\"$name\"/d" "$CURRENT"
+    [[ -f "$FULL" ]] && sed -i "/\"$name\"/d" "$FULL"
+    [[ -f "$FAST" ]] && sed -i "/\"$name\"/d" "$FAST"
+
+    # Remove symlink if it is one (don't delete actual files)
+    if [[ -L "$CONFIG_DIR/$name" ]]; then
+        rm "$CONFIG_DIR/$name"
+        echo "  Removed symlink: $CONFIG_DIR/$name"
+    fi
+
+    echo -e "${GREEN}Removed $name from the KB configuration.${NC}"
+    echo -e "${BLUE}Restart jEdit or Sigma to reload the KB.${NC}"
+}
+
+list_files() {
+    echo "Constituent files in current config:"
+    grep 'constituent filename' "$CURRENT" | sed 's/.*filename="\([^"]*\)".*/  \1/' | while read -r f; do
+        if [[ -L "$CONFIG_DIR/$f" ]]; then
+            echo "$f -> $(readlink "$CONFIG_DIR/$f")"
+        else
+            echo "$f"
+        fi
+    done
+}
+
 show_status() {
     local mode=$(detect_mode)
     echo -e "Current mode: ${GREEN}$mode${NC}"
@@ -159,6 +299,15 @@ case "${1:-status}" in
         ;;
     fast)
         switch_fast
+        ;;
+    add)
+        add_file "$2"
+        ;;
+    remove|rm)
+        remove_file "$2"
+        ;;
+    list|ls)
+        list_files
         ;;
     status)
         show_status


### PR DESCRIPTION
## Summary

- Adds `add` command: symlinks a dev .kif file into `KBs/` and inserts a `<constituent>` entry in config.xml (plus config-full.xml and config-fast.xml if they exist)
- Adds `remove` command: removes a .kif file from config and cleans up its symlink (blocks removal of core files like Merge.kif)
- Adds `list` command: shows all constituent files in the current config, with symlink targets

## Test plan

- [x] 12 new test cases added to `test/scripts/sigma-config-test.sh`
- [x] All 21 tests passing (9 original + 12 new)

```
--- add command ---
PASS: Add a .kif file to config
PASS: Add creates symlink in KBs dir
PASS: Add same file twice is idempotent
PASS: Add nonexistent file fails
PASS: Add non-.kif file fails
PASS: Add propagates to full and fast configs

--- remove command ---
PASS: Remove file from config
PASS: Remove cleans up symlink
PASS: Remove core file is blocked
PASS: Remove file not in config fails

--- list command ---
PASS: List shows constituent files

--- round-trip ---
PASS: Full->fast->full preserves constituents

Results: 21/21 passed
All tests passed!
```