### PR TITLE
411 move from formula to formulaast and kif to sigmaantlr

### DIFF
--- a/src/java/com/articulate/sigma/parsing/PredVarInst.java
+++ b/src/java/com/articulate/sigma/parsing/PredVarInst.java
@@ -147,6 +147,11 @@ public class PredVarInst {
                             if (fr.pred.equals(var)) {  // have to update the row var record to reflect the pred var substitution
                                 fr.pred = rel;
                                 fr.literal = fr.literal.replace(var, rel);
+                                // Predicate variables don't increment argnum during parsing, so
+                                // rs.arity is 1 short (it counts only non-pred args). Now that a
+                                // concrete predicate occupies the head position, add 1 so findArities()
+                                // computes the correct rowVarArity for @ROW expansion.
+                                fr.arity += 1;
                             }
                         }
                     }

--- a/src/java/com/articulate/sigma/parsing/RowVar.java
+++ b/src/java/com/articulate/sigma/parsing/RowVar.java
@@ -406,8 +406,12 @@ public class RowVar {
             if (!pred.equals("__quantList")) {
                 Integer valence = kb.kbCache.valences.get(pred);
                 if (valence != null && valence == -1) {
-                    // VariableArityRelation: rename predicate to pred_totalArity[Fn]
-                    int totalArity = computeTotalArity(pred, rowVarName, n, fa);
+                    // VariableArityRelation: rename predicate to pred_totalArity[Fn].
+                    // Use newArgs.size() directly — it is always correct after @ROW splicing
+                    // and avoids the Set-ordering ambiguity in computeTotalArity() when the
+                    // same pred appears with different arities under the same row variable
+                    // (e.g. (ListFn @ROW ?ITEM) and (ListFn @ROW) in the same formula).
+                    int totalArity = newArgs.size();
                     String fnSuffix = pred.endsWith(Formula.FN_SUFF) ? Formula.FN_SUFF : "";
                     String newPredName = pred + "__" + totalArity + fnSuffix;
                     newHead = new Expr.Atom(newPredName);

--- a/src/java/com/articulate/sigma/trans/SUMOKBtoTFAKB.java
+++ b/src/java/com/articulate/sigma/trans/SUMOKBtoTFAKB.java
@@ -260,6 +260,12 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
         }
         output = output + " : $i  ).";
         pw.println(output);
+        // Also declare the non-__m version so formulas using the symbol without __m are typed
+        if (t.endsWith(Formula.TERM_MENTION_SUFFIX)) {
+            String labelNoM = label + "_noM";
+            String symbolNoM = t.substring(0, t.length() - Formula.TERM_MENTION_SUFFIX.length());
+            pw.println("tff(" + labelNoM + ",type," + symbolNoM + " : $i  ).");
+        }
     }
 
     /** *************************************************************
@@ -284,7 +290,12 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
         pw.println("% SUMOKBtoTFAKB.writeRelationSort(): " + t);
         if (t.endsWith(Formula.FN_SUFF) != kb.isFunction(t))
             System.err.println("Error in writeRelationSort(): is function mismatch with term name : " + t + ", " + kb.isFunction(t));
-        if (Formula.isLogicalOperator(t) || Formula.isMathFunction(t)  || Formula.isComparisonOperator(t)) {
+        String bareTerm = SUMOtoTFAform.getBareTerm(t);
+        boolean isLeoUnsupportedMath = bareTerm.equals(Formula.REMAINDERFN) ||
+                bareTerm.equals(Formula.DIVIDEFN) || bareTerm.equals(Formula.FLOORFN) ||
+                bareTerm.equals(Formula.CEILINGFN) || bareTerm.equals(Formula.ROUNDFN);
+        if (Formula.isLogicalOperator(t) || (Formula.isMathFunction(bareTerm) && !isLeoUnsupportedMath)
+                || Formula.isComparisonOperator(t)) {
             String label = translateName(t);
             String output = "tff(" + label + ",type," + label +
                     " : $i ).";
@@ -295,7 +306,7 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
         int endIndex = sig.size();
         if (KButilities.isVariableArity(kb,SUMOtoTFAform.withoutSuffix(t)))
             endIndex = getVariableAritySuffix(t) + 1;
-        if (endIndex > 8) {
+        if (endIndex > 9) {
             pw.println("% SUMOKBtoTFAKB.writeRelationSort(): size too large: " + t);
             return;
         }
@@ -303,8 +314,14 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
             System.err.println("Error in SUMOKBtoTFAKB.writeRelationSort(): " + t + " variable arity relation without suffix");
             endIndex = sig.size();
         }
-        if (endIndex > sig.size())
-            endIndex = sig.size();
+        if (endIndex > sig.size()) {
+            // Pad sig to required length by repeating last type (mirrors copyNewPredFromVariableArity)
+            String lastType = sig.get(sig.size() - 1);
+            List<String> paddedSig = new ArrayList<>(sig);
+            while (paddedSig.size() < endIndex)
+                paddedSig.add(lastType);
+            sig = paddedSig;
+        }
         if (sig == null || sig.isEmpty()) {
             pw.println("% Error in SUMOKBtoTFAKB.writeRelationSort(): no sig for " + t);
             System.err.println("Error in SUMOKBtoTFAKB.writeRelationSort(): no sig for " + t);
@@ -547,6 +564,10 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
         }
         for (String suffix : finalsuffixes)
             MapUtils.addToMap(toExtend, "ListFn", suffix);
+        // Plain entity-typed variants (all args $i): ListFn__1Fn .. ListFn__7Fn.
+        // These have no type-annotation suffix and are not covered by the typed permutations above.
+        for (int i = 1; i <= 7; i++)
+            MapUtils.addToMap(toExtend, "ListFn", Integer.toString(i));
     }
 
     /** *************************************************************
@@ -570,9 +591,8 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
                 continue;
             sig = kb.kbCache.getSignature(r);
             size = sig.size();
-            System.out.println("SUMOKBtoTFAKB.handleVariableArity(): r,sig,size: " + r + Formula.SPACE + sig + " size " + size);
-            if (size > 1)
-                size = size - 1;  // first sig element is range, some sig elements before variable arity element may be fixed and explicit
+            // Always start from arity 1: (?REL @ROW) instantiation can expand any
+            // VariableArityRelation to arity 1..7 regardless of its normal minimum arity.
             inStr = new StringBuilder();
             reStr = new StringBuilder();
             raStr = new StringBuilder();
@@ -587,13 +607,11 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
             if (kb.isFunction(r))
                 fnSuffix = Formula.FN_SUFF;
             if (hasNumericArg(r) || listOperator(r)) {
-                for (int i = size; i <= 7; i++) {
-                    //if (expandableArg(r,i,sig)) {
+                for (int i = 1; i <= 7; i++) {
                     inStr.append(Integer.toString(i)).append("In");
                     reStr.append(Integer.toString(i)).append("Re");
                     raStr.append(Integer.toString(i)).append("Ra");
                     enStr.append(Integer.toString(i)).append("En");
-                    //}
                     newInStr = Integer.toString(i) + fnSuffix + "__" + inStr.toString();
                     newReStr = Integer.toString(i) + fnSuffix + "__" + reStr.toString();
                     newRaStr = Integer.toString(i) + fnSuffix + "__" + raStr.toString();
@@ -604,10 +622,11 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
                     MapUtils.addToMap(toExtend, r, newEnStr);
                 }
             }
-            else {
-                for (int i = size; i < 7; i++) {
-                    MapUtils.addToMap(toExtend, r, Integer.toString(i));
-                }
+            // All variable-arity relations also need plain numeric entries because
+            // RowVar.java always generates plain numeric suffixes (e.g. AssignmentFn__7Fn).
+            // Go to 8: one fixed arg + 7 @ROW elements = totalArity 8.
+            for (int i = 1; i <= 8; i++) {
+                MapUtils.addToMap(toExtend, r, Integer.toString(i));
             }
         }
     }
@@ -678,6 +697,16 @@ public class SUMOKBtoTFAKB extends SUMOKBtoTPTPKB {
                     writeRelationSort(newTerm, pw);
                 }
             }
+        }
+        // Explicitly declare mention forms ($i) for all math functions.
+        // processRecurseExpr calls translateWord without "tff" lang, so AdditionFn used as
+        // a first-class term (e.g. identityElement AdditionFn 0) becomes s__AdditionFn__m
+        // rather than the TPTP built-in $sum__m. We must declare it.
+        // Use TERM_SYMBOL_PREFIX directly — translateName() would add __m itself (no-arg path).
+        for (String mathFn : Formula.MATH_FUNCTIONS) {
+            String symbol = Formula.TERM_SYMBOL_PREFIX + mathFn;
+            String mentionSymbol = symbol + Formula.TERM_MENTION_SUFFIX;
+            pw.println("tff(" + symbol + "_m,type," + mentionSymbol + " : $i ).");
         }
         pw.flush();
         pw.println("% SUMOKBtoTFAKB.writeSorts(): finished\n");

--- a/src/java/com/articulate/sigma/trans/SUMOKBtoTPTPKB.java
+++ b/src/java/com/articulate/sigma/trans/SUMOKBtoTPTPKB.java
@@ -788,7 +788,7 @@ public class SUMOKBtoTPTPKB {
                         !alreadyWrittenTPTPs.contains(sort)) {
                     name = "kb_" + getSanitizedKBname() + "_" + axiomIndex.getAndIncrement();
                     putAxiom(name,f);
-                    pw.println(getLang() + Formula.LP + name + ",axiom,(" + sort + ")).");
+                    pw.println(getLang() + Formula.LP + name + ",type," + sort + ").");
                     alreadyWrittenTPTPs.add(sort);
                 }
             }
@@ -1271,7 +1271,7 @@ public class SUMOKBtoTPTPKB {
                 if (!alreadyWrittenTPTPs.contains(sort)) {
                     name = "kb_" + getSanitizedKBname() + "_" + axiomIndex.getAndIncrement();
                     putAxiom(name, res.formula);
-                    linesBuf.add(localLang + Formula.LP + name + ",axiom,(" + sort + ")).");
+                    linesBuf.add(localLang + Formula.LP + name + ",type," + sort + ").");
                     alreadyWrittenTPTPs.add(sort);
                 }
             }

--- a/src/java/com/articulate/sigma/trans/SUMOformulaToTPTPformula.java
+++ b/src/java/com/articulate/sigma/trans/SUMOformulaToTPTPformula.java
@@ -211,7 +211,7 @@ public class SUMOformulaToTPTPformula {
                 }
             }
             else {
-                return (Formula.TERM_SYMBOL_PREFIX + st.substring(1).replace('-','_'));
+                return (Formula.TERM_SYMBOL_PREFIX + st.replace('-','_'));
             }
 
         }

--- a/src/java/com/articulate/sigma/trans/SUMOtoTFAform.java
+++ b/src/java/com/articulate/sigma/trans/SUMOtoTFAform.java
@@ -102,9 +102,26 @@ public class SUMOtoTFAform {
     public static boolean isMathFunction(String s) {
 
         int under = s.lastIndexOf("__");
-        if (under == -1)
-            return Formula.isMathFunction(s);
-        return Formula.isMathFunction(s.substring(0,under));
+        String base = (under == -1) ? s : s.substring(0, under);
+        // These have no LEO-III-supported TPTP built-in; fall through to s__Xxx SUMO function translation
+        if (base.equals(Formula.REMAINDERFN) || base.equals(Formula.DIVIDEFN) ||
+                base.equals(Formula.FLOORFN) || base.equals(Formula.CEILINGFN) ||
+                base.equals(Formula.ROUNDFN))
+            return false;
+        return Formula.isMathFunction(base);
+    }
+
+    /** *************************************************************
+     * Returns true for math functions whose KB cache signature may be
+     * unreliable (Entity instead of RealNumber/Integer), requiring
+     * makePredFromArgTypes to always be called so the type-suffixed
+     * name is used and extendRelationSig derives the sort from the name.
+     */
+    private static boolean needsForcedTypeSuffix(String pred) {
+        int under = pred.lastIndexOf("__");
+        String base = (under == -1) ? pred : pred.substring(0, under);
+        return base.equals(Formula.DIVIDEFN) || base.equals(Formula.FLOORFN) ||
+               base.equals(Formula.CEILINGFN) || base.equals(Formula.ROUNDFN);
     }
 
     /** *************************************************************
@@ -258,6 +275,20 @@ public class SUMOtoTFAform {
         if (VAR_ARITY_PATTERN.matcher(rel).matches())
             return relationExtractNonNumericSig(rel);
         String text = rel.substring(under + 2, rel.length());
+        // Plain arity-N function variant with no type annotations, e.g. ListFn__7Fn.
+        // The text is just "NFn" — no SIG_PART_PATTERN match possible.
+        if (text.matches("\\d+Fn")) {
+            String bareRel = rel.substring(0, under);
+            int arity = Integer.parseInt(text.substring(0, text.length() - 2)); // strip "Fn"
+            List<String> baseSig = kb.kbCache.signatures.get(bareRel);
+            String range   = (baseSig != null && !baseSig.isEmpty() && !StringUtil.emptyString(baseSig.get(0)))
+                             ? baseSig.get(0) : "Entity";
+            String varType = kb.kbCache.variableArityType(bareRel);
+            if (varType == null || varType.isEmpty()) varType = "Entity";
+            sig.add(range);
+            for (int i = 1; i <= arity; i++) sig.add(varType);
+            return sig;
+        }
         Matcher matcher = SIG_PART_PATTERN.matcher(text);
         String type;
         while (matcher.find()) {
@@ -755,7 +786,7 @@ public class SUMOtoTFAform {
         if (debug) System.out.println("SUMOtoTFAform.processNumericSuperArgs(): newArgTypes: " + newArgTypes);
         String pred = car.getFormula();
         List<String> sig = kb.kbCache.getSignature(pred);
-        if (!equalTFFsig(newArgTypes,sig,pred) || KButilities.isVariableArity(kb,pred))
+        if (!equalTFFsig(newArgTypes,sig,pred) || KButilities.isVariableArity(kb,pred) || needsForcedTypeSuffix(pred))
             pred = makePredFromArgTypes(car,newArgTypes);
         if (debug) System.out.println("SUMOtoTFAform.processNumericSuperArgs(): pred: " + pred);
         List<String> processedArgs = new ArrayList<>();
@@ -906,45 +937,27 @@ public class SUMOtoTFAform {
 
     /** *************************************************************
      * When the arguments to quotient are mixed, promote the more
-     * specific type to the more general type
+     * specific type to the more general type.
+     * Each argument is promoted individually only when its own type is
+     * more specific than mgt; arguments already at the target type are
+     * left unwrapped (avoids redundant $to_real on already-$real values).
      */
     private static String mixedQuotient(Formula f, String op,
                                         String parentType,
                                         List<String> args,
                                         List<String> argTypes) {
 
-        HashSet hs = new HashSet();
-        hs.addAll(argTypes);
-        if (hs.size() == 1)
         if (debug) System.out.println("SUMOtoTFAform.mixedQuotient(): f: " + f);
         if (debug) System.out.println("SUMOtoTFAform.mixedQuotient(): argTypes: " + argTypes);
         String mgt = "Entity";
         if (argTypes != null && argTypes.size() > 2)
-            mgt = bestOfPair(argTypes.get(1),argTypes.get(2));
+            mgt = bestOfPair(argTypes.get(1), argTypes.get(2));
         if (debug) System.out.println("SUMOtoTFAform.mixedQuotient(): most general: " + mgt);
-        String promote = "";
         Formula lhs = new Formula(args.get(1));
         Formula rhs = new Formula(args.get(2));
-        String eSuffix = "_e";
-        if (mgt != null) {
-            if (mgt.equals("RealNumber")) {
-                promote = "$to_real";
-                eSuffix = "";
-            }
-            if (mgt.equals("RationalNumber")) {
-                promote = "$to_rat";
-                eSuffix = "";
-            }
-        }
-        if ("".equals(promote)) {
-            System.err.println("Error in SUMOtoTFAform.mixedQuotient() with args: " + args +
-                    " and types " + argTypes + " in formula: " + f);
-            return "$quotient" + eSuffix + Formula.LP + processRecurse(lhs,parentType) + " ," +
-                    processRecurse(rhs,parentType) + Formula.RP;
-        }
-        else
-            return "$quotient" + eSuffix + Formula.LP + promote + Formula.LP + processRecurse(lhs,parentType) + ") ," +
-                    promote + Formula.LP + processRecurse(rhs,parentType) + "))";
+        String lhsResult = processRecurse(lhs, parentType);
+        String rhsResult = processRecurse(rhs, parentType);
+        return "$quotient_e" + Formula.LP + lhsResult + " ," + rhsResult + Formula.RP;
     }
 
     /** *************************************************************
@@ -1006,13 +1019,6 @@ public class SUMOtoTFAform {
                 return mixedQuotient(f,op,parentType,args,argTypes);
             }
         }
-        if (op.startsWith(Formula.REMAINDERFN))
-            if (allOfType(args,"Integer"))
-                return promotion + "$remainder_e(" + processRecurse(arg1,arg1Type) + " ," +
-                    processRecurse(arg2,arg2Type) + Formula.RP + closeP;
-            else
-                return promotion + "$remainder_t(" + processRecurse(arg1,arg1Type) + " ," +
-                        processRecurse(arg2,arg2Type) + Formula.RP + closeP;
         System.err.println("Error in SUMOtoTFAform.processMathOp(): bad math operator " + op + " in " + f);
         return "";
     }
@@ -1041,7 +1047,7 @@ public class SUMOtoTFAform {
                 kb.isSubclass("RealNumber",argTypes.get(0))) {
             String best = bestOfPair(argTypes.get(0),parentType);
             newArgTypes.set(0,best);
-            if (!equalTFFsig(newArgTypes,sig,op) || KButilities.isVariableArity(kb,op)) // only add the suffix if arg types are different from the original sort of the predicate
+            if (!equalTFFsig(newArgTypes,sig,op) || KButilities.isVariableArity(kb,op) || needsForcedTypeSuffix(op)) // only add the suffix if arg types are different from the original sort of the predicate
                 op = makePredFromArgTypes(car,newArgTypes);
         }
         List<String> origArgTypes = new ArrayList<>(newArgTypes); // save actual arg types before bestSignature
@@ -1233,14 +1239,7 @@ public class SUMOtoTFAform {
         if (debug) System.out.println("SUMOtoTFAform.numTypePromotion(): isNumericType(parentType): " + isNumericType(parentType));
         if (findType(f) != null)
             if (debug) System.out.println("SUMOtoTFAform.numTypePromotion(): kb.compareTermDepth(findType(f),parentType): " + kb.compareTermDepth(findType(f),parentType));
-        if (isNumeric(f) && isNumericType(parentType) && findType(f) != null &&
-                kb.compareTermDepth(findType(f),parentType) > 0) {
-            if (debug) System.out.println("SUMOtoTFAform.numTypePromotion(): promoting");
-            if (parentType.equals("RealNumber"))
-                return "$to_real(";
-            if (parentType.equals("RationalNumber"))
-                return "$to_rat(";
-        }
+        // $to_real and $to_rat are not supported by LEO-III; skip promotion
         return null;
     }
 
@@ -1265,9 +1264,9 @@ public class SUMOtoTFAform {
             String result;
             if (debug) System.out.println("SUMOtoTFAform.processRecurse(): promotion: " + promotion);
             if (promotion != null)
-                result = promotion + SUMOformulaToTPTPformula.translateWord(f.getFormula(),ttype,false) + Formula.RP;
+                result = promotion + SUMOformulaToTPTPformula.translateWord(f.getFormula(),ttype,false,"tff") + Formula.RP;
             else
-                result = SUMOformulaToTPTPformula.translateWord(f.getFormula(),ttype,false);
+                result = SUMOformulaToTPTPformula.translateWord(f.getFormula(),ttype,false,"tff");
             if (debug) System.out.println("SUMOtoTFAform.processRecurse(): result: " + result);
             return result;
         }
@@ -2391,11 +2390,10 @@ public class SUMOtoTFAform {
             String range = sig.get(0);
             if (StringUtil.emptyString(range))
                 range = "Entity";
-            //return("tff(" + StringUtil.initialLowerCase(axname) + "_sig,type," + rel + " : ( " + sigStr + " ) > " + SUMOKBtoTFAKB.translateSort(kb,range) + " ).");
-            return(rel + " : ( " + sigStr + " ) > " + SUMOKBtoTFAKB.translateSort(kb,range));
+            return(relname + " : ( " + sigStr + " ) > " + SUMOKBtoTFAKB.translateSort(kb,range));
         }
         else
-            return(rel + " : ( " + sigStr + " ) > $o ");
+            return(relname + " : ( " + sigStr + " ) > $o ");
     }
 
     /** *************************************************************
@@ -3092,13 +3090,7 @@ public class SUMOtoTFAform {
 
     /** Numeric promotion – mirrors numTypePromotion(Formula, String). */
     private static String numTypePromotionExpr(Expr expr, String parentType) {
-        String type = findTypeExpr(expr);
-        if (type == null) return null;
-        if (isNumericExpr(expr) && isNumericType(parentType) &&
-                kb.compareTermDepth(type, parentType) > 0) {
-            if (parentType.equals("RealNumber"))     return "$to_real(";
-            if (parentType.equals("RationalNumber")) return "$to_rat(";
-        }
+        // $to_real and $to_rat are not supported by LEO-III; skip promotion
         return null;
     }
 
@@ -3269,24 +3261,11 @@ public class SUMOtoTFAform {
         String mgt = "Entity";
         if (argTypes != null && argTypes.size() > 2)
             mgt = bestOfPair(argTypes.get(1), argTypes.get(2));
-        String promote = "";
-        String eSuffix = "_e";
-        if (mgt != null) {
-            if (mgt.equals("RealNumber"))     { promote = "$to_real"; eSuffix = ""; }
-            if (mgt.equals("RationalNumber")) { promote = "$to_rat";  eSuffix = ""; }
-        }
         Expr lhsExpr = se.args().get(0);
         Expr rhsExpr = se.args().get(1);
-        if ("".equals(promote)) {
-            System.err.println("Error in SUMOtoTFAform.mixedQuotientExpr() with args: " +
-                argStrings + " and types " + argTypes);
-            return "$quotient" + eSuffix + Formula.LP +
-                    processRecurseExpr(lhsExpr, parentType) + " ," +
-                    processRecurseExpr(rhsExpr, parentType) + Formula.RP;
-        }
-        return "$quotient" + eSuffix + Formula.LP +
-                promote + Formula.LP + processRecurseExpr(lhsExpr, parentType) + ") ," +
-                promote + Formula.LP + processRecurseExpr(rhsExpr, parentType) + "))";
+        String lhsResult = processRecurseExpr(lhsExpr, parentType);
+        String rhsResult = processRecurseExpr(rhsExpr, parentType);
+        return "$quotient_e" + Formula.LP + lhsResult + " ," + rhsResult + Formula.RP;
     }
 
     private static String processMathOpExpr(Expr.SExpr se, String parentType,
@@ -3340,14 +3319,6 @@ public class SUMOtoTFAform {
             else
                 return mixedQuotientExpr(se, parentType, argStrings, argTypes);
         }
-        if (op.startsWith(Formula.REMAINDERFN)) {
-            if (allOfType(argStrings, "Integer"))
-                return promotion + "$remainder_e(" + processRecurseExpr(arg1, arg1Type) + " ," +
-                        processRecurseExpr(arg2, arg2Type) + Formula.RP + closeP;
-            else
-                return promotion + "$remainder_t(" + processRecurseExpr(arg1, arg1Type) + " ," +
-                        processRecurseExpr(arg2, arg2Type) + Formula.RP + closeP;
-        }
         System.err.println("Error in SUMOtoTFAform.processMathOpExpr(): " +
             "bad math operator " + op + " in " + se.toKifString());
         return "";
@@ -3385,7 +3356,7 @@ public class SUMOtoTFAform {
         newArgTypes = bestSignature(predTypes, newArgTypes);
         String pred = op;
         List<String> sig = kb.kbCache.getSignature(pred);
-        if (!equalTFFsig(newArgTypes, sig, pred) || KButilities.isVariableArity(kb, pred))
+        if (!equalTFFsig(newArgTypes, sig, pred) || KButilities.isVariableArity(kb, pred) || needsForcedTypeSuffix(pred))
             pred = makePredFromArgTypes(new Formula(pred), newArgTypes);
         List<String> processedArgs = new ArrayList<>();
         for (int i = 0; i < args.size(); i++) {
@@ -3417,7 +3388,7 @@ public class SUMOtoTFAform {
                 !argTypes.isEmpty() && kb.isSubclass("RealNumber", argTypes.get(0))) {
             String best = bestOfPair(argTypes.get(0), parentType);
             newArgTypes.set(0, best);
-            if (!equalTFFsig(newArgTypes, sig, op) || KButilities.isVariableArity(kb, op))
+            if (!equalTFFsig(newArgTypes, sig, op) || KButilities.isVariableArity(kb, op) || needsForcedTypeSuffix(op))
                 op = makePredFromArgTypes(new Formula(op), newArgTypes);
         }
         List<String> origArgTypes = new ArrayList<>(newArgTypes); // save actual arg types before bestSignature
@@ -3456,7 +3427,7 @@ public class SUMOtoTFAform {
                 }
                 if (!(argExpr instanceof Expr.SExpr))
                     argStr.append(SUMOformulaToTPTPformula.translateWord(
-                            argExpr.toKifString(), argExpr.toKifString().charAt(0), false))
+                            argExpr.toKifString(), argExpr.toKifString().charAt(0), false, "tff"))
                           .append(", ");
                 else
                     argStr.append(processRecurseExpr(argExpr, type)).append(", ");


### PR DESCRIPTION
# LEO-III-STC TFF Compatibility Fixes

This document describes all changes made to make SigmaKEE's generated TFF file
acceptable to **LEO-III-STC---1.7.20**, a strict higher-order theorem prover with
a subset of TPTP arithmetic built-ins. The changes also preserve compatibility
with Vampire.

---

## 1. Remove unsupported arithmetic built-ins

**Files:** `SUMOtoTFAform.java`, `SUMOKBtoTFAKB.java`

### Problem
LEO-III-STC does not support the following TPTP arithmetic built-ins:
- `$to_real`, `$to_rat` — numeric type coercions
- `$remainder_e`, `$remainder_t` — remainder functions
- `$quotient_e` (when reached via type-promotion logic for `DivisionFn`)

The old code used these in `numTypePromotion`, `mixedQuotient`, and the
`RemainderFn` translation path.

### Fix

#### `SUMOtoTFAform.isMathFunction` override
Overrides `Formula.isMathFunction` to return `false` for `RemainderFn`,
`DivisionFn`, `FloorFn`, `CeilingFn`, and `RoundFn`. This prevents the
translator from routing them through the TPTP arithmetic built-in path
(`$sum`, `$product`, etc.) and instead falls through to the SUMO-prefixed
function translation (`s__RemainderFn__...`, `s__DivisionFn__...`, etc.).

```java
if (base.equals(Formula.REMAINDERFN) || base.equals(Formula.DIVIDEFN) ||
        base.equals(Formula.FLOORFN) || base.equals(Formula.CEILINGFN) ||
        base.equals(Formula.ROUNDFN))
    return false;
```

#### `numTypePromotion` / `numTypePromotionExpr`
Both the Formula path and Expr path now always return `null`, disabling
`$to_real` and `$to_rat` coercions entirely.

#### `mixedQuotient` / `mixedQuotientExpr`
Simplified to always emit `$quotient_e` without any type-promotion wrapper,
eliminating `$to_real`/`$to_rat` calls.

#### `processMathOp` / `processMathOpExpr` — `RemainderFn`
Removed the `$remainder_e` / `$remainder_t` emission block for `RemainderFn`.
Since `isMathFunction` now returns `false` for it, `RemainderFn` is translated
as a SUMO function and never reaches `processMathOp`.

#### `SUMOKBtoTFAKB.writeRelationSort` — `isLeoUnsupportedMath` guard
Added an exclusion so that `RemainderFn`, `DivisionFn`, `FloorFn`, `CeilingFn`,
and `RoundFn` are **not** given the `$i` shortcut that math functions normally
receive. Without this, Vampire would see `s__RemainderFn of type ($i * $i) > $i`
and fail to create a function application.

```java
boolean isLeoUnsupportedMath = bareTerm.equals(Formula.REMAINDERFN) || ...;
if (Formula.isLogicalOperator(t) || (Formula.isMathFunction(bareTerm) && !isLeoUnsupportedMath)
        || Formula.isComparisonOperator(t)) { ... }
```

---

## 2. Force type-suffixed names for unreliable-cache math functions

**File:** `SUMOtoTFAform.java`

### Problem
`DivisionFn`, `FloorFn`, `CeilingFn`, and `RoundFn` have unreliable KB cache
signatures (the cache stores `Entity` instead of `RealNumber`/`Integer`).
`equalTFFsig` would conclude the signature matches and skip `makePredFromArgTypes`,
leaving a bare `s__DivisionFn` that Vampire sees as `($i * $i) > $i` and
rejects for typed arithmetic expressions.

### Fix
Added `needsForcedTypeSuffix(pred)` helper:

```java
private static boolean needsForcedTypeSuffix(String pred) {
    String base = (under == -1) ? pred : pred.substring(0, under);
    return base.equals(Formula.DIVIDEFN) || base.equals(Formula.FLOORFN) ||
           base.equals(Formula.CEILINGFN) || base.equals(Formula.ROUNDFN);
}
```

This is checked alongside `equalTFFsig` in four call sites:
`processNumericSuperArgs`, `processOtherRelation`, `processNumericSuperArgsExpr`,
and `processOtherRelationExpr`. When true, `makePredFromArgTypes` is always called
so the type-annotated variant name (e.g. `DivisionFn__0Re1Re2ReFn`) is used and
`extendRelationSig` derives the sort reliably from the name.

---

## 3. Fix `translateWord` dropping the first character of inequality terms

**File:** `SUMOformulaToTPTPformula.java`

### Problem
In the inequality branch of `translateWord_1`, the code called
`st.substring(1)`, which stripped the first character from the term name.
This caused `lessThan` → `s__essThan` and `greaterThan` → `s__reaterThan`,
both of which are unknown to LEO-III.

### Fix
```java
// Before
return (Formula.TERM_SYMBOL_PREFIX + st.substring(1).replace('-','_'));
// After
return (Formula.TERM_SYMBOL_PREFIX + st.replace('-','_'));
```

---

## 4. Fix `processRecurse` atom path using wrong TPTP lang

**File:** `SUMOtoTFAform.java`

### Problem
`processRecurse` called `translateWord(f.getFormula(), ttype, false)` without
passing `"tff"` as the language. This bypassed the `kifFunctions` lookup (which
maps e.g. `AdditionFn` → `$sum`) and fell through to a generic path that could
produce wrong symbol names.

### Fix
Pass `"tff"` explicitly:
```java
result = SUMOformulaToTPTPformula.translateWord(f.getFormula(), ttype, false, "tff");
```
The same fix was applied in `processOtherRelationExpr` where atom arguments were
translated without the lang parameter.

---

## 5. Fix `tffSorts` role and syntax

**File:** `SUMOKBtoTPTPKB.java`

### Problem
Per-formula sort declarations were emitted with role `axiom` and wrapped in extra
parentheses:
```
tff(name, axiom, (s__Foo : ($i) > $o)).
```
LEO-III requires the `type` role and no outer parentheses:
```
tff(name, type, s__Foo : ($i) > $o).
```

### Fix
Changed both write sites (sequential `writeFile` path and parallel `_tWriteFile`
path) from `",axiom,(" + sort + "))"` to `",type," + sort + ")"`.

---

## 6. Fix `sortFromRelation` emitting bare symbol without `s__` prefix

**File:** `SUMOtoTFAform.java`

### Problem
`sortFromRelation` built sort strings using the bare `rel` name (without the
`s__` prefix) as the symbol, e.g. `ListFn__7Fn : ($i * ... ) > $i`. LEO-III
expects the `s__`-prefixed symbol.

### Fix
Use `relname` (which already has the `s__` prefix from `SUMOKBtoTFAKB.translateName`)
instead of bare `rel` in both the function and predicate return branches.

---

## 7. Add type declarations for `greaterThan` and similar comparison symbols

**File:** `SUMOKBtoTFAKB.java` — `writeSort`

### Problem
When `greaterThan__m` was encountered as a term (mention form), only the `__m`
variant was declared. Formulas that used `greaterThan` directly (without `__m`)
had no type declaration.

### Fix
Added a `_noM` companion declaration in `writeSort`: when emitting a `__m`
symbol, also emit the non-`__m` version:

```java
if (t.endsWith(Formula.TERM_MENTION_SUFFIX)) {
    String symbolNoM = t.substring(0, t.length() - Formula.TERM_MENTION_SUFFIX.length());
    pw.println("tff(" + label + "_noM,type," + symbolNoM + " : $i  ).");
}
```

---

## 8. Fix `writeRelationSort` for suffixed math function forms

**File:** `SUMOKBtoTFAKB.java`

### Problem
The math-function `$i` shortcut checked `Formula.isMathFunction(t)` against the
exact term string. For suffixed forms such as `AdditionFn__m`, `AdditionFn__0Re1Re2ReFn`,
etc., the exact check failed (those strings are not in `MATH_FUNCTIONS`), causing
the method to fall through to `kb.kbCache.signatures.get(t)` which returns `null`
and throws a NullPointerException.

### Fix
Use `bareTerm` (the suffix-stripped form) for the check:
```java
String bareTerm = SUMOtoTFAform.getBareTerm(t);
if (...(Formula.isMathFunction(bareTerm) && !isLeoUnsupportedMath)...) { ... }
```

---

## 9. Fix variable-arity sort declarations for arity-8 predicates

**File:** `SUMOKBtoTFAKB.java` — `writeRelationSort`

### Problem
Two bugs prevented type declarations for predicates with arity 8 (e.g.
`s__exhaustiveAttribute__8`, `s__AssignmentFn__8Fn`):

1. `if (endIndex > 8) return;` — arity 8 requires `endIndex = 9`, which
   tripped the guard.
2. `endIndex = sig.size()` — capped `endIndex` at the (short) base signature
   size instead of padding to the required arity.

`RowVar.java` expands `@ROW` to up to 7 elements. For predicates that have one
fixed argument before `@ROW` (e.g. `exhaustiveAttribute ?CLASS @ROW`),
`totalArity = 1 + 7 = 8`.

### Fix
1. Raise threshold: `endIndex > 8` → `endIndex > 9`.
2. Pad the signature instead of capping it, mirroring `copyNewPredFromVariableArity`:

```java
if (endIndex > sig.size()) {
    String lastType = sig.get(sig.size() - 1);
    List<String> paddedSig = new ArrayList<>(sig);
    while (paddedSig.size() < endIndex)
        paddedSig.add(lastType);
    sig = paddedSig;
}
```

---

## 10. Fix `handleVariableArity` missing plain numeric entries for list operators

**File:** `SUMOKBtoTFAKB.java` — `handleVariableArity`

### Problem
`handleVariableArity` had two branches:
- `hasNumericArg || listOperator` → emitted only typed entries
  (e.g. `AssignmentFn__7Fn__1En2En3En4En5En6En7En`)
- `else` → emitted plain numeric entries (e.g. `"7"` → `AssignmentFn__7Fn`)

`listOperator` returns `true` for `AssignmentFn` (and all numeric-arg relations),
so they only got typed entries. But `RowVar.java` always generates plain numeric
suffixes (`AssignmentFn__7Fn`). Without a plain declaration, LEO-III reported
`s__AssignmentFn__7Fn has unknown type`.

Additionally, the typed-entry loop started from `size` (the base signature size)
instead of 1, missing lower arities that `(?REL @ROW)` instantiation can produce.

### Fix
- Start the typed-entry loop from `i = 1` (not `size`).
- Remove the `else` branch and unconditionally add plain numeric entries
  `"1"` through `"8"` for **all** variable-arity relations:

```java
// After the if (hasNumericArg || listOperator) block:
for (int i = 1; i <= 8; i++) {
    MapUtils.addToMap(toExtend, r, Integer.toString(i));
}
```

---

## 11. Add plain numeric entries for `ListFn`

**File:** `SUMOKBtoTFAKB.java` — `handleListFn`

### Problem
`handleListFn` only emitted typed permutations (e.g. `ListFn__7Fn__1En2En...`).
`RowVar.java` also generates plain `ListFn__7Fn`, `ListFn__1Fn`, etc.
These had no type declarations.

### Fix
After the typed permutation loop, add plain numeric entries:
```java
for (int i = 1; i <= 7; i++)
    MapUtils.addToMap(toExtend, "ListFn", Integer.toString(i));
```

---

## 12. Fix `relationExtractSigFromName` for plain arity-N function variants

**File:** `SUMOtoTFAform.java`

### Problem
`relationExtractSigFromName` could not extract a signature for names like
`ListFn__7Fn` (plain numeric suffix, no type-annotation letters). The
`SIG_PART_PATTERN` (`\d(In|Re|Ra|En)`) found no matches, so the returned
signature was empty, causing incorrect sort declarations.

### Fix
Added a `text.matches("\\d+Fn")` branch that reads the arity from the suffix
and builds the signature from the base relation's range type and variable-arity
type:

```java
if (text.matches("\\d+Fn")) {
    int arity = Integer.parseInt(text.substring(0, text.length() - 2));
    // build sig from base range + arity × varType
}
```

---

## 13. Fix double-suffix bug in `RowVar.spliceRowVar`

**File:** `RowVar.java`

### Problem
When the same predicate appeared with different arities under the same row
variable (e.g. `(ListFn @ROW ?ITEM)` and `(ListFn @ROW)` in the same formula),
`computeTotalArity` iterated a `Set<RowStruct>` and returned the first matching
`RowStruct` for **both** occurrences. If the higher-arity struct was found first,
both uses got renamed `ListFn__2Fn`. The TFF translator then saw `ListFn__2Fn`
used with only 1 argument, called `makePredFromArgTypes` on it, and produced the
double-suffixed name `ListFn__2Fn__1Fn`, which had no type declaration.

### Fix
After `@ROW` has been spliced into `newArgs`, `newArgs.size()` is exactly the
correct total arity for that specific occurrence. Use it directly:

```java
// Before
int totalArity = computeTotalArity(pred, rowVarName, n, fa);
// After
int totalArity = newArgs.size();
```

---

## 14. Declare mention forms of math functions

**File:** `SUMOKBtoTFAKB.java` — `writeSorts`

### Problem
`processRecurseExpr` calls `translateWord` without the `"tff"` language
parameter. For `AdditionFn` used as a first-class term (e.g.
`(identityElement AdditionFn 0)`), the general no-arg path fires:
`endsWith("Fn")` → appends `__m` → produces `s__AdditionFn__m` rather than
the TPTP built-in `$sum__m`. Because `AdditionFn__m` is a synthetic name
(not in `kb.terms`), `writeSorts` never emitted a type declaration for it.

### Fix
At the end of `writeSorts`, unconditionally emit `$i` declarations for all
math function mention forms. `translateName` is avoided because it also adds
`__m` (no-arg path), which would produce `s__AdditionFn__m__m`. Instead,
`TERM_SYMBOL_PREFIX` is used directly:

```java
for (String mathFn : Formula.MATH_FUNCTIONS) {
    String symbol = Formula.TERM_SYMBOL_PREFIX + mathFn;           // s__AdditionFn
    String mentionSymbol = symbol + Formula.TERM_MENTION_SUFFIX;   // s__AdditionFn__m
    pw.println("tff(" + symbol + "_m,type," + mentionSymbol + " : $i ).");
}
```

---

## 15. Fix `@ROW` over-expansion for predicate-variable formulas

**File:** `PredVarInst.java`

### Problem

Formulas of the form `(?REL ?AGENT @ROW)` where `?REL` is a predicate variable produce
wrong row-variable expansions after `PredVarInst` substitutes the concrete relation.

During parsing, predicate **variables** (e.g. `?REL`) do not increment `argnum` (unlike
concrete identifiers), so `RowStruct.arity` ends up 1 short:

| Literal | Recorded `rs.arity` | Should be |
|---------|---------------------|-----------|
| `(?REL ?AGENT @ROW)` | 1 | 2 |
| `(?REL @ROW)` | 0 | 1 |

`PredVarInst.processOne()` updates `fr.pred` and `fr.literal` after substitution but not
`fr.arity`. `RowVar.findArities()` then computes `rowVarArity = predArity − (arity − 1)`
with the stale arity, yielding a value that is 1 too large.

For `(serviceProvider ?AGENT @ROW)` after instantiation:
- stale `rs.arity = 1` → `rowVarArity = 2 − 0 = 2` → @ROW expands to 2 elements
- result: `s__serviceProvider(V__AGENT, V__ROW1, V__ROW2)` — 3 args vs. binary declaration

For `(prefers ?AGENT @ROW)` after instantiation (ternary):
- stale `rs.arity = 1` → `rowVarArity = 3 − 0 = 3` → @ROW expands to 3 elements
- result: `s__prefers(V__AGENT, V__ROW1, V__ROW2, V__ROW3)` — 4 args vs. ternary declaration

LEO-III reports `NotWellTypedException` on all such formulas.

### Fix

Add `fr.arity += 1` inside the predicate-variable substitution block:

```java
if (fr.pred.equals(var)) {
    fr.pred = rel;
    fr.literal = fr.literal.replace(var, rel);
    // Predicate variables don't increment argnum during parsing, so
    // rs.arity is 1 short. Add 1 so findArities() computes the correct
    // rowVarArity for @ROW expansion.
    fr.arity += 1;
}
```

After the fix, `findArities` computes:
- `serviceProvider`: `rowVarArity = 2 − (2−1) = 1` → `(serviceProvider ?AGENT ROW1)` = 2 args ✓
- `prefers`: `rowVarArity = 3 − (2−1) = 2` → `(prefers ?AGENT ROW1 ROW2)` = 3 args ✓
