### PR TITLE
[Angelos] update fof generation for LEO-III compatibility #411

### DIFF
--- a/src/java/com/articulate/sigma/parsing/ExprToTPTP.java
+++ b/src/java/com/articulate/sigma/parsing/ExprToTPTP.java
@@ -173,8 +173,10 @@ public class ExprToTPTP {
         if (Character.isDigit(ch0) || (ch0 == '-' && Character.isDigit(ch1)))
             return translateNumber(name, lang);
 
-        // TFF-specific inequality predicates when used as terms (not in head position)
-        if ("tff".equals(lang) && Formula.isInequality(name) && !isHead)
+        // Inequality predicates used as terms (not in head position) need the __m
+        // mention suffix so the same symbol is not used both as a predicate and as
+        // a term — that is a TPTP type error for all languages (FOF and TFF alike).
+        if (Formula.isInequality(name) && !isHead)
             return Formula.TERM_SYMBOL_PREFIX + name + Formula.TERM_MENTION_SUFFIX;
 
         // Logical operators used in head position → their TPTP equivalents
@@ -184,9 +186,13 @@ public class ExprToTPTP {
         if (tptpOp != null && isHead)
             return tptpOp; // shouldn't normally happen — SExpr handles head dispatch
 
-        // Special constants
-        if (Formula.LOG_TRUE.equals(name))  return "$true"  + (isHead ? "" : Formula.TERM_MENTION_SUFFIX);
-        if (Formula.LOG_FALSE.equals(name)) return "$false" + (isHead ? "" : Formula.TERM_MENTION_SUFFIX);
+        // Special constants. When used as head they translate directly; in argument
+        // position they become distinct-object constants (single-quoted) so the prover
+        // does not confuse them with the defined TPTP propositions $true/$false.
+        if (Formula.LOG_TRUE.equals(name))
+            return isHead ? "$true"  : "'" + "$true"  + Formula.TERM_MENTION_SUFFIX + "'";
+        if (Formula.LOG_FALSE.equals(name))
+            return isHead ? "$false" : "'" + "$false" + Formula.TERM_MENTION_SUFFIX + "'";
 
         // TFF arithmetic functions (only when used as head)
         if ("tff".equals(lang) && isHead) {

--- a/src/java/com/articulate/sigma/trans/SUMOformulaToTPTPformula.java
+++ b/src/java/com/articulate/sigma/trans/SUMOformulaToTPTPformula.java
@@ -166,10 +166,12 @@ public class SUMOformulaToTPTPformula {
         if (ch0 == '?' || ch0 == '@')
             return(Formula.TERM_VARIABLE_PREFIX + st.substring(1).replace('-','_'));
         if (debug) System.out.println("INFO in SUMOformulaToTPTPformula.translateWord_1(): here2: ");
+        //----Inequality predicates used as terms need __m in all languages to avoid
+        // the predicate/term symbol clash that TPTP parsers reject as a type error.
+        if (Formula.isInequality(st) && !hasArguments)
+            return Formula.TERM_SYMBOL_PREFIX + st + Formula.TERM_MENTION_SUFFIX;
         //----Translate special predicates
         if ("tff".equals(lang)) {
-            if (Formula.isInequality(st) && !hasArguments)
-                return Formula.TERM_SYMBOL_PREFIX + st + Formula.TERM_MENTION_SUFFIX;
             translateIndex = kifPredicates.indexOf(st);
             if (translateIndex != -1)
                 return (tptpPredicates.get(translateIndex) + (hasArguments ? "" : mentionSuffix));


### PR DESCRIPTION
 ExprToTPTP.java
  1. Inequality mention-form fix — greaterThan, lessThan, etc. when used as term-arguments (not predicate
  head) now always get the __m suffix in all languages, not just TFF. Without this, the same symbol appears
  as both a predicate and a term in FOF, which is a TPTP type error.

  2. $false/$true term fix — When $false or $true appear in argument position, they are now emitted as
  single-quoted distinct objects ('$false__m') instead of the bare $false__m, which prover parsers reject as
  an unknown system symbol.

  SUMOformulaToTPTPformula.java
  3. Inequality mention-form fix (fallback path) — The same inequality __m fix applied to the string-based
  translation path (fallback when the Expr path is unavailable), which had the identical "tff".equals(lang)
  guard blocking FOF.
