### PR TITLE
Added Mutual Dependencies to Diagnostics

### DIFF
--- a/src/java/com/articulate/sigma/Diagnostics.java
+++ b/src/java/com/articulate/sigma/Diagnostics.java
@@ -95,7 +95,7 @@ public class Diagnostics {
      */
     public static List termsWithoutDoc(KB kb) {
 
-        if (debug) System.out.println("INFO in Diagnostics.termsWithoutDoc(): ");
+        System.out.println("INFO in Diagnostics.termsWithoutDoc(): ");
         return termsWithoutRelation(kb,"documentation",1,' ');
     }
 
@@ -173,7 +173,7 @@ public class Diagnostics {
      */
     public static List<String> termsNotBelowEntity(KB kb) {
 
-        if (debug) System.out.println("INFO in Diagnostics.termsNotBelowEntity(): ");
+        System.out.println("INFO in Diagnostics.termsNotBelowEntity(): ");
         List<String> result = new ArrayList<>();
         int count = 0;
         String term;
@@ -200,7 +200,7 @@ public class Diagnostics {
      */
     public static List<String> partitionViolation(KB kb) {
 
-        if (debug) System.out.println("Partition violations:");
+        System.out.println("Partition violations:");
         List<String> result = new ArrayList<>();
         List<Formula> flist = kb.ask("arg",0,"partition");
         for (Formula f : flist) {
@@ -214,7 +214,7 @@ public class Diagnostics {
                     if (!subs.contains(newSub)) {
                         String s = "Error in partitionViolation(): " + subf +
                                 " not part of " + f;
-                        if (debug) System.out.println(s);
+                        System.out.println(s);
                         result.add(s);
                     }
                 }
@@ -697,8 +697,7 @@ public class Diagnostics {
      */
     private static Map<String,Map<String,List<String>>> termDependency(KB kb) {
 
-        debug = true;
-        if (debug) System.out.println("INFO in Diagnostics.termDependency()");
+        System.out.println("INFO in Diagnostics.termDependency()");
 
         // A map of terms keys with an ArrayList as values listing files
         // in which the term is used.
@@ -781,19 +780,21 @@ public class Diagnostics {
         // on which the given file depends.  The interior TreeMap file name
         // keys index ArrayLists of terms.  file -depends on-> filenames -that defines-> terms
         Map<String,Map<String,List<String>>> fileDepends = Diagnostics.termDependency(kb);
-        if (debug) System.out.println("Diagnostics.printTermDependency(): fileDepends /n" + fileDepends);
+        System.out.println(fileDepends);
         Map<String,List<String>> tm;
         List<String> al;
         String term;
         int i;
         for (String f : fileDepends.keySet()) {
+
             // result.append("File " + f + " depends on: ");
             tm = fileDepends.get(f);
             for (String f2 : tm.keySet()) {
+                if (StringUtil.removeFilePath(f).equals("SUMO_Cache.kif") || StringUtil.removeFilePath(f2).equals("SUMO_Cache.kif")) continue;
                 al = tm.get(f2);
 
                 if (al != null && al.size() < 40) {
-                    result.append("<br/>File ").append(f).append(" dependency size on file ").append(f2).append(" is ").append(al.size()).append(" with terms:<br/>");
+                    result.append("<br/>File ").append(StringUtil.removeFilePath(f)).append(" dependency size on file ").append(StringUtil.removeFilePath(f2)).append(" is ").append(al.size()).append(" with terms:<br/>");
                     for (int ix = 0; ix < al.size(); ix++) {
                         term = (String) al.get(ix);
                         result.append("<a href=\"").append(kbHref).append("&term=").append(term).append("\">").append(term).append("</a>");
@@ -805,7 +806,7 @@ public class Diagnostics {
                 else {
                     i = dependencySize(fileDepends, f, f2);
                     if (i > 0)
-                        result.append("<br/>File ").append(f).append(" dependency size on file ").append(f2).append(" is ").append(i).append("<P>");
+                        result.append("<br/>File ").append(StringUtil.removeFilePath(f)).append(" dependency size on file ").append(StringUtil.removeFilePath(f2)).append(" is ").append(i).append("<P>");
                 }
                 // if (al != null
                 // && (dependencySize(fileDepends, f, f2) > al.size() || al
@@ -847,185 +848,113 @@ public class Diagnostics {
         return result.toString();
     }
 
-/***************************************************************
- * @param termDependency a TreeMap of file name keys and an ArrayList of the
- *         files on which it depends. The interior TreeMap file
- *         name keys index ArrayLists of terms.
- */
-private static List<String> createDependDotGraphBody(Map<String,Map<String,List<String>>> termDependency) {
+    /***************************************************************
+     * @param termDependency a TreeMap of file name keys and an ArrayList of the
+     *         files on which it depends. The interior TreeMap file
+     *         name keys index ArrayLists of terms.
+     */
+    private static List<String> createDependDotGraphBody(Map<String,Map<String,List<String>>> termDependency) {
 
-    List<String> lines = new ArrayList<>();
-
-    // All graph nodes that should be shown
-    Set<String> nodes = new HashSet<>();
-
-    // Count of how many files depend on a given node (incoming edges)
-    Map<String,Integer> incomingCounts = new HashMap<>();
-
-    // Store edges so we can output them after node collection
-    List<String[]> edges = new ArrayList<>();
-
-    // First pass: collect nodes and compute incoming edge counts
-    for (String filename : termDependency.keySet()) {
-
-        String nameOnly = sanitizeFilenameForGraphViz(filename);
-        if (nameOnly.equals("SUMO_Cache"))
-            continue;
-
-        if (debug) System.out.println("createDependDotGraphBody(): file = " + filename);
-
-        nodes.add(nameOnly);
-        incomingCounts.putIfAbsent(nameOnly, 0);
-
-        Map<String,List<String>> dependencyMap = termDependency.get(filename);
-        if (dependencyMap != null) {
-            for (String otherFile : dependencyMap.keySet()) {
-
-                String otherNameOnly = sanitizeFilenameForGraphViz(otherFile);
-                if (otherNameOnly.equals("SUMO_Cache"))
-                    continue;
-
-                nodes.add(otherNameOnly);
-                incomingCounts.putIfAbsent(otherNameOnly, 0);
-
-                // filename depends on otherFile
-                edges.add(new String[]{nameOnly, otherNameOnly});
-
-                // otherFile is depended upon by filename
-                incomingCounts.put(otherNameOnly, incomingCounts.get(otherNameOnly) + 1);
+        List<String> lines = new ArrayList<>();
+        String line;
+        for (String filename : termDependency.keySet()) {
+            String nameOnly = sanitizeFilenameForGraphViz(filename);
+            if (debug) System.out.println("createDependDotGraphBody()" + filename);
+            String newline = nameOnly + " [shape=\"box\" label = < " + nameOnly +
+                    " <br align=\"left\"/> > ]";
+            lines.add(newline);
+            if (termDependency.get(filename) != null) {
+                for (String otherFile : termDependency.get(filename).keySet()) {
+                    String otherNameOnly = sanitizeFilenameForGraphViz(otherFile);
+                    line = nameOnly + " -> " + otherNameOnly + "; ";
+                    lines.add(line);
+                }
             }
         }
+        return lines;
     }
 
-    // Output node declarations
-    for (String node : nodes) {
-        String newline = node + " [shape=\"box\" label = < " + node + " <br align=\"left\"/> > ]";
-        lines.add(newline);
+    /** *************************************************************
+     */
+    public static String sanitizeFilenameForGraphViz(String s) {
+
+        return FileUtil.noExt(FileUtil.noPath(s)).replace("-","_");
     }
 
-    // Output edge declarations
-    for (String[] edge : edges) {
-        String line = edge[0] + " -> " + edge[1] + ";";
-        lines.add(line);
+    /** *************************************************************
+     * Creates a specified formatted image from a generated *.dot file
+     * from GraphViz.
+     *
+     * @param filename the generated *.dot filename to create an image from
+     * @return the path to the generated image file
+     */
+    public static String createDependDotGraphImage(String filename) throws IOException {
+
+        int exitCode;
+        String retVal = "";
+        String graphVizDir = KBmanager.getMgr().getPref("graphVizDir");
+        String imageExt = KBmanager.getMgr().getPref("imageFormat");
+        if (imageExt == null || imageExt.isBlank())
+            imageExt = "png"; // default
+        File file = new File(filename + "." + imageExt);
+
+        List<String> cmd = new ArrayList<>();
+        cmd.add(graphVizDir + File.separator + "dot");
+        cmd.add("-T" + imageExt);
+        cmd.add("-O");
+        cmd.add(filename);
+        System.out.println(cmd);
+        try {
+            // Build a dependency graph image from an input file
+            // From: https://graphviz.org/doc/info/command.html#-O
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.directory(file.getParentFile());
+            File log = new File(file.getParentFile(),"log");
+            if (log.exists())
+                log.delete();
+            pb.redirectErrorStream(true);
+            pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log)); // <- in case of any errors
+            Process proc = pb.start();
+            exitCode = proc.waitFor();
+        } catch (InterruptedException e) {
+            String err = "Error writing file " + file + "\n" + e.getMessage();
+            throw new IOException(err);
+        }
+        retVal = file.getAbsolutePath();
+        return retVal;
     }
 
-    // Group nodes by how many incoming edges they have
-    // Highest counts first so the most depended-upon nodes are ranked highest
-    Map<Integer,List<String>> rankGroups = new TreeMap<>(Collections.reverseOrder());
-    for (String node : nodes) {
-        int count = incomingCounts.getOrDefault(node, 0);
-        rankGroups.computeIfAbsent(count, k -> new ArrayList<>()).add(node);
-    }
+    /**
+     * *************************************************************
+     * Create a dependency graphin a format suitable for GraphViz' input format
+     * http://www.graphviz.org/. Generate a dependency image from the .dot output
+     * with a command like <code>dot SUMO-graph.dot -Tgif > graph.gif</code>
+     */
+    public static void createDependDotGraph(Map<String,Map<String,List<String>>> termDependency) {
 
-    // Force nodes with the same incoming edge count to share the same rank
-    for (Map.Entry<Integer,List<String>> entry : rankGroups.entrySet()) {
-        List<String> group = entry.getValue();
-        if (!group.isEmpty()) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("{ rank=same; ");
-            for (String node : group)
-                sb.append(node).append("; ");
-            sb.append("}");
-            lines.add(sb.toString());
+        String sep = File.separator;
+        String dir = System.getenv("CATALINA_HOME") + sep + "webapps"
+                + sep + "sigma" + sep + "graph";
+        File dirfile = new File(dir);
+        if (!dirfile.exists())
+            dirfile.mkdirs();
+        String filename = dirfile.getPath() + sep + "depend.dot";
+        Path path = Paths.get(filename);
+        try (Writer bw = Files.newBufferedWriter(path, StandardCharsets.UTF_8); PrintWriter pw = new PrintWriter(bw, true)) {
+            Set<String> result = new HashSet<>();
+            result.addAll(createDependDotGraphBody(termDependency));
+            pw.println("digraph G {");
+            pw.println("  node [color=black, fontcolor=black];"); // Black text and borders
+            pw.println("  edge [color=black];"); // Black edges
+            pw.println("  rankdir=LR");
+            for (String s : result)
+                pw.println(s);
+            pw.println("}");
+            System.out.println(createDependDotGraphImage(path.toString()));
+        } catch (IOException e) {
+            String err = "Error writing file " + path + "\n" + e.getMessage();
         }
     }
-
-    return lines;
-}
-
-/** *************************************************************
- */
-public static String sanitizeFilenameForGraphViz(String s) {
-
-    return FileUtil.noExt(FileUtil.noPath(s)).replace("-","_");
-}
-
-/** *************************************************************
- * Creates a specified formatted image from a generated *.dot file
- * from GraphViz.
- *
- * @param filename the generated *.dot filename to create an image from
- * @return the path to the generated image file
- */
-public static String createDependDotGraphImage(String filename) throws IOException {
-
-    int exitCode;
-    String retVal = "";
-    String graphVizDir = KBmanager.getMgr().getPref("graphVizDir");
-    String imageExt = KBmanager.getMgr().getPref("imageFormat");
-    if (imageExt == null || imageExt.isBlank())
-        imageExt = "png"; // default
-    File file = new File(filename + "." + imageExt);
-
-    List<String> cmd = new ArrayList<>();
-    cmd.add(graphVizDir + File.separator + "dot");
-    cmd.add("-T" + imageExt);
-    cmd.add("-O");
-    cmd.add(filename);
-    if (debug) System.out.println(cmd);
-    try {
-        // Build a dependency graph image from an input file
-        // From: https://graphviz.org/doc/info/command.html#-O
-        ProcessBuilder pb = new ProcessBuilder(cmd);
-        pb.directory(file.getParentFile());
-        File log = new File(file.getParentFile(),"log");
-        if (log.exists())
-            log.delete();
-        pb.redirectErrorStream(true);
-        pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log)); // <- in case of any errors
-        Process proc = pb.start();
-        exitCode = proc.waitFor();
-    }
-    catch (InterruptedException e) {
-        String err = "Error writing file " + file + "\n" + e.getMessage();
-        throw new IOException(err);
-    }
-    retVal = file.getAbsolutePath();
-    return retVal;
-}
-
-/**
- * *************************************************************
- * Create a dependency graph in a format suitable for GraphViz' input format
- * http://www.graphviz.org/. Generate a dependency image from the .dot output
- * with a command like <code>dot SUMO-graph.dot -Tgif > graph.gif</code>
- */
-public static void createDependDotGraph(Map<String,Map<String,List<String>>> termDependency) {
-
-    String sep = File.separator;
-    String dir = System.getenv("CATALINA_HOME") + sep + "webapps"
-            + sep + "sigma" + sep + "graph";
-    File dirfile = new File(dir);
-    if (!dirfile.exists())
-        dirfile.mkdirs();
-    String filename = dirfile.getPath() + sep + "depend.dot";
-    Path path = Paths.get(filename);
-
-    try (Writer bw = Files.newBufferedWriter(path, StandardCharsets.UTF_8);
-         PrintWriter pw = new PrintWriter(bw, true)) {
-
-        List<String> result = createDependDotGraphBody(termDependency);
-
-        pw.println("digraph G {");
-        pw.println("  node [color=black, fontcolor=black];");
-        pw.println("  edge [color=black];");
-
-        // Top-to-bottom so heavily depended-on nodes appear higher
-        pw.println("  rankdir=BT;");
-        pw.println("  nodesep=0.35;");
-        pw.println("  ranksep=0.75;");
-
-        for (String s : result)
-            pw.println("  " + s);
-
-        pw.println("}");
-        if (debug) System.out.println(createDependDotGraphImage(path.toString()));
-    }
-    catch (IOException e) {
-        String err = "Error writing file " + path + "\n" + e.getMessage();
-        System.err.println(err);
-    }
-}
 
     /** *****************************************************************
      * Make an empty KB for use in Diagnostics.
@@ -1043,7 +972,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
         String emptyCFilename = emptyCFile.getAbsolutePath();
         KBmanager.getMgr().addKB(kbName);
         KB empty = KBmanager.getMgr().getKB(kbName);
-        if (debug) System.out.println("empty = " + empty);
+        System.out.println("empty = " + empty);
 
         // Fails elsewhere if no constituents, or empty constituent, thus...
         try (Writer fw = new FileWriter( emptyCFile );
@@ -1115,7 +1044,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
         StringBuilder answer = new StringBuilder();
         KB empty = makeEmptyKB("consistencyCheck");
 
-        if (debug) System.out.println("=================== Consistency Testing ===================");
+        System.out.println("=================== Consistency Testing ===================");
         try {
             FormulaPreprocessor fp;
             String processedQuery;
@@ -1128,11 +1057,11 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                 //System.out.println(" query = " + query);
                 //System.out.println(" processedQueries = " + processedQueries);
 
-                if (debug) System.out.println("INFO in Diagnostics.kbConsistencyCheck(): size = " + processedQueries.size());
+                System.out.println("INFO in Diagnostics.kbConsistencyCheck(): size = " + processedQueries.size());
                 for (Formula f : processedQueries) {
-                    if (debug) System.out.println("INFO in Diagnostics.kbConsistencyCheck(): formula = " + f.getFormula());
+                    System.out.println("INFO in Diagnostics.kbConsistencyCheck(): formula = " + f.getFormula());
                     processedQuery = f.makeQuantifiersExplicit(false);
-                    if (debug) System.out.println("INFO in Diagnostics.kbConsistencyCheck(): processedQuery = " + processedQuery);
+                    System.out.println("INFO in Diagnostics.kbConsistencyCheck(): processedQuery = " + processedQuery);
                     proof = empty.askEProver(processedQuery,timeout,maxAnswers) + " ";
                     a = new StringBuilder();
                     a.append(reportAnswer(kb,proof,query,processedQuery,"Redundancy"));
@@ -1182,14 +1111,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                     tformstrs.add(str);
                 }
                 simpleName = fname.substring(fname.lastIndexOf('/')+1,fname.length());
-                if (debug) System.out.print(t + "\t" + simpleName + "\t");
+                System.out.print(t + "\t" + simpleName + "\t");
                 int i = 0;
                 for (String st : tformstrs) {
                     if (i < 3)
-                        if (debug) System.out.print(st + "\t");
+                        System.out.print(st + "\t");
                     i++;
                 }
-                if (debug) System.out.println();
+                System.out.println();
             }
         }
     }
@@ -1199,7 +1128,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
      */
     public static void termDefsByGivenFile(KB kb, Set<String> files) {
 
-        if (debug) System.out.println("termDefsByGivenFile(): files: " + files);
+        System.out.println("termDefsByGivenFile(): files: " + files);
         Set<String> alreadyCounted = new HashSet<>();
         Map<String,Set<String>> termsByFile = new HashMap<>();
         String fname, simpleName, str;
@@ -1254,14 +1183,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                     str = f.getStringArgument(3);
                     tformstrs.add(str);
                 }
-                if (debug) System.out.print(term + "\t" + fnam + "\t");
+                System.out.print(term + "\t" + fnam + "\t");
                 int i = 0;
                 for (String st : tformstrs) {
                     if (i < 3)
-                        if (debug) System.out.print(st + "\t");
+                        System.out.print(st + "\t");
                     i++;
                 }
-                if (debug) System.out.println();
+                System.out.println();
             }
         }
     }
@@ -1282,14 +1211,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                 str = f.getStringArgument(3);
                 tformstrs.add(str);
             }
-            if (debug) System.out.print(term + "\t");
+            System.out.print(term + "\t");
             i = 0;
             for (String st : tformstrs) {
                 if (i < 3)
-                    if (debug) System.out.print(st + "\t");
+                    System.out.print(st + "\t");
                 i++;
             }
-            if (debug) System.out.println();
+            System.out.println();
         }
     }
 
@@ -1298,7 +1227,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
     public static void printAllTerms(KB kb) {
 
         for (String t : kb.terms)
-            if (debug) System.out.println(t);
+            System.out.println(t);
     }
 
     /** ***************************************************************
@@ -1337,14 +1266,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                 str = f.getStringArgument(3);
                 tformstrs.add(str);
             }
-            if (debug) System.out.print(term + "\t"); //  + fname + "\t");
+            System.out.print(term + "\t"); //  + fname + "\t");
             int i = 0;
             for (String st : tformstrs) {
                 if (i < 3)
-                    if (debug) System.out.print(st + "\t");
+                    System.out.print(st + "\t");
                 i++;
             }
-            if (debug) System.out.println();
+            System.out.println();
         }
     }
 
@@ -1673,8 +1602,8 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                     // a variable appearing multiple times, e.g., on both sides of an implication is intentional usage, not an orphan
                     int count = countOccurrences(f.getFormula(), var);
                     if (count == 1) {
-                        if (debug) System.out.println("\nWARNING in formula: " + f.getFormula());
-                        if (debug) System.out.println("  Orphan variable found: " + var);
+                        System.out.println("\nWARNING in formula: " + f.getFormula());
+                        System.out.println("  Orphan variable found: " + var);
                         hasOrphans = true;
                         foundAnyWarnings = true;
                     }
@@ -1684,10 +1613,10 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
             if (!hasOrphans && !map.isEmpty()) {
                 ArrayList<HashSet<String>> groups = findDisconnectedGroups(map);
                 if (groups.size() > 1) {
-                    if (debug) System.out.println("\nWARNING in formula: " + f.getFormula());
-                    if (debug) System.out.println("  Formula has " + groups.size() + " variable groups that are disconnected from each other:");
+                    System.out.println("\nWARNING in formula: " + f.getFormula());
+                    System.out.println("  Formula has " + groups.size() + " variable groups that are disconnected from each other:");
                     for (int i = 0; i < groups.size(); i++) {
-                        if (debug) System.out.println("    Group " + (i + 1) + ": " + groups.get(i));
+                        System.out.println("    Group " + (i + 1) + ": " + groups.get(i));
                     }
                     foundAnyWarnings = true;
                 }
@@ -1695,7 +1624,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
             mergeResults(links, map);
         }
         if (!foundAnyWarnings) {
-            if (debug) System.out.println("\nNo variable connectivity issues found.");
+            System.out.println("\nNo variable connectivity issues found.");
         }
         return links;
     }

--- a/src/java/com/articulate/sigma/Diagnostics.java
+++ b/src/java/com/articulate/sigma/Diagnostics.java
@@ -846,116 +846,186 @@ public class Diagnostics {
         return result.toString();
     }
 
-    /***************************************************************
-     * @param termDependency a TreeMap of file name keys and an ArrayList of the
-     *         files on which it depends. The interior TreeMap file
-     *         name keys index ArrayLists of terms.
-     */
-    private static List<String> createDependDotGraphBody(Map<String,Map<String,List<String>>> termDependency) {
+/***************************************************************
+ * @param termDependency a TreeMap of file name keys and an ArrayList of the
+ *         files on which it depends. The interior TreeMap file
+ *         name keys index ArrayLists of terms.
+ */
+private static List<String> createDependDotGraphBody(Map<String,Map<String,List<String>>> termDependency) {
 
-        List<String> lines = new ArrayList<>();
-        String line;
-        for (String filename : termDependency.keySet()) {
-            String nameOnly = sanitizeFilenameForGraphViz(filename);
-            if(!nameOnly.equals("SUMO_Cache")) {
-                if (debug) System.out.println("createDependDotGraphBody()" + filename);
-                String newline = nameOnly + " [shape=\"box\" label = < " + nameOnly + " <br align=\"left\"/> > ]";
-                lines.add(newline);
-                if (termDependency.get(filename) != null) {
-                    for (String otherFile : termDependency.get(filename).keySet()) {
-                        String otherNameOnly = sanitizeFilenameForGraphViz(otherFile);
-                        if(!otherNameOnly.equals("SUMO_Cache")) {
-                            line = nameOnly + " -> " + otherNameOnly + "; ";
-                            lines.add(line);
-                        }
-                    }
-                }
+    List<String> lines = new ArrayList<>();
+
+    // All graph nodes that should be shown
+    Set<String> nodes = new HashSet<>();
+
+    // Count of how many files depend on a given node (incoming edges)
+    Map<String,Integer> incomingCounts = new HashMap<>();
+
+    // Store edges so we can output them after node collection
+    List<String[]> edges = new ArrayList<>();
+
+    // First pass: collect nodes and compute incoming edge counts
+    for (String filename : termDependency.keySet()) {
+
+        String nameOnly = sanitizeFilenameForGraphViz(filename);
+        if (nameOnly.equals("SUMO_Cache"))
+            continue;
+
+        if (debug)
+            System.out.println("createDependDotGraphBody(): file = " + filename);
+
+        nodes.add(nameOnly);
+        incomingCounts.putIfAbsent(nameOnly, 0);
+
+        Map<String,List<String>> dependencyMap = termDependency.get(filename);
+        if (dependencyMap != null) {
+            for (String otherFile : dependencyMap.keySet()) {
+
+                String otherNameOnly = sanitizeFilenameForGraphViz(otherFile);
+                if (otherNameOnly.equals("SUMO_Cache"))
+                    continue;
+
+                nodes.add(otherNameOnly);
+                incomingCounts.putIfAbsent(otherNameOnly, 0);
+
+                // filename depends on otherFile
+                edges.add(new String[]{nameOnly, otherNameOnly});
+
+                // otherFile is depended upon by filename
+                incomingCounts.put(otherNameOnly, incomingCounts.get(otherNameOnly) + 1);
             }
         }
-        return lines;
     }
 
-    /** *************************************************************
-     */
-    public static String sanitizeFilenameForGraphViz(String s) {
-
-        return FileUtil.noExt(FileUtil.noPath(s)).replace("-","_");
+    // Output node declarations
+    for (String node : nodes) {
+        String newline = node + " [shape=\"box\" label = < " + node + " <br align=\"left\"/> > ]";
+        lines.add(newline);
     }
 
-    /** *************************************************************
-     * Creates a specified formatted image from a generated *.dot file
-     * from GraphViz.
-     *
-     * @param filename the generated *.dot filename to create an image from
-     * @return the path to the generated image file
-     */
-    public static String createDependDotGraphImage(String filename) throws IOException {
-
-        int exitCode;
-        String retVal = "";
-        String graphVizDir = KBmanager.getMgr().getPref("graphVizDir");
-        String imageExt = KBmanager.getMgr().getPref("imageFormat");
-        if (imageExt == null || imageExt.isBlank())
-            imageExt = "png"; // default
-        File file = new File(filename + "." + imageExt);
-
-        List<String> cmd = new ArrayList<>();
-        cmd.add(graphVizDir + File.separator + "dot");
-        cmd.add("-T" + imageExt);
-        cmd.add("-O");
-        cmd.add(filename);
-        System.out.println(cmd);
-        try {
-            // Build a dependency graph image from an input file
-            // From: https://graphviz.org/doc/info/command.html#-O
-            ProcessBuilder pb = new ProcessBuilder(cmd);
-            pb.directory(file.getParentFile());
-            File log = new File(file.getParentFile(),"log");
-            if (log.exists())
-                log.delete();
-            pb.redirectErrorStream(true);
-            pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log)); // <- in case of any errors
-            Process proc = pb.start();
-            exitCode = proc.waitFor();
-        } catch (InterruptedException e) {
-            String err = "Error writing file " + file + "\n" + e.getMessage();
-            throw new IOException(err);
-        }
-        retVal = file.getAbsolutePath();
-        return retVal;
+    // Output edge declarations
+    for (String[] edge : edges) {
+        String line = edge[0] + " -> " + edge[1] + ";";
+        lines.add(line);
     }
 
-    /**
-     * *************************************************************
-     * Create a dependency graphin a format suitable for GraphViz' input format
-     * http://www.graphviz.org/. Generate a dependency image from the .dot output
-     * with a command like <code>dot SUMO-graph.dot -Tgif > graph.gif</code>
-     */
-    public static void createDependDotGraph(Map<String,Map<String,List<String>>> termDependency) {
+    // Group nodes by how many incoming edges they have
+    // Highest counts first so the most depended-upon nodes are ranked highest
+    Map<Integer,List<String>> rankGroups = new TreeMap<>(Collections.reverseOrder());
+    for (String node : nodes) {
+        int count = incomingCounts.getOrDefault(node, 0);
+        rankGroups.computeIfAbsent(count, k -> new ArrayList<>()).add(node);
+    }
 
-        String sep = File.separator;
-        String dir = System.getenv("CATALINA_HOME") + sep + "webapps"
-                + sep + "sigma" + sep + "graph";
-        File dirfile = new File(dir);
-        if (!dirfile.exists())
-            dirfile.mkdirs();
-        String filename = dirfile.getPath() + sep + "depend.dot";
-        Path path = Paths.get(filename);
-        try (Writer bw = Files.newBufferedWriter(path, StandardCharsets.UTF_8); PrintWriter pw = new PrintWriter(bw, true)) {
-            Set<String> result = new HashSet<>();
-            result.addAll(createDependDotGraphBody(termDependency));
-            pw.println("digraph G {");
-            pw.println("  node [color=black, fontcolor=black];"); // Black text and borders
-            pw.println("  edge [color=black];"); // Black edges
-            pw.println("  rankdir=LR");
-            for (String s : result)
-                pw.println(s);
-            pw.println("}");
-            System.out.println(createDependDotGraphImage(path.toString()));
-        } catch (IOException e) {
-            String err = "Error writing file " + path + "\n" + e.getMessage();
+    // Force nodes with the same incoming edge count to share the same rank
+    for (Map.Entry<Integer,List<String>> entry : rankGroups.entrySet()) {
+        List<String> group = entry.getValue();
+        if (!group.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("{ rank=same; ");
+            for (String node : group)
+                sb.append(node).append("; ");
+            sb.append("}");
+            lines.add(sb.toString());
         }
     }
+
+    return lines;
+}
+
+/** *************************************************************
+ */
+public static String sanitizeFilenameForGraphViz(String s) {
+
+    return FileUtil.noExt(FileUtil.noPath(s)).replace("-","_");
+}
+
+/** *************************************************************
+ * Creates a specified formatted image from a generated *.dot file
+ * from GraphViz.
+ *
+ * @param filename the generated *.dot filename to create an image from
+ * @return the path to the generated image file
+ */
+public static String createDependDotGraphImage(String filename) throws IOException {
+
+    int exitCode;
+    String retVal = "";
+    String graphVizDir = KBmanager.getMgr().getPref("graphVizDir");
+    String imageExt = KBmanager.getMgr().getPref("imageFormat");
+    if (imageExt == null || imageExt.isBlank())
+        imageExt = "png"; // default
+    File file = new File(filename + "." + imageExt);
+
+    List<String> cmd = new ArrayList<>();
+    cmd.add(graphVizDir + File.separator + "dot");
+    cmd.add("-T" + imageExt);
+    cmd.add("-O");
+    cmd.add(filename);
+    System.out.println(cmd);
+    try {
+        // Build a dependency graph image from an input file
+        // From: https://graphviz.org/doc/info/command.html#-O
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.directory(file.getParentFile());
+        File log = new File(file.getParentFile(),"log");
+        if (log.exists())
+            log.delete();
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log)); // <- in case of any errors
+        Process proc = pb.start();
+        exitCode = proc.waitFor();
+    }
+    catch (InterruptedException e) {
+        String err = "Error writing file " + file + "\n" + e.getMessage();
+        throw new IOException(err);
+    }
+    retVal = file.getAbsolutePath();
+    return retVal;
+}
+
+/**
+ * *************************************************************
+ * Create a dependency graph in a format suitable for GraphViz' input format
+ * http://www.graphviz.org/. Generate a dependency image from the .dot output
+ * with a command like <code>dot SUMO-graph.dot -Tgif > graph.gif</code>
+ */
+public static void createDependDotGraph(Map<String,Map<String,List<String>>> termDependency) {
+
+    String sep = File.separator;
+    String dir = System.getenv("CATALINA_HOME") + sep + "webapps"
+            + sep + "sigma" + sep + "graph";
+    File dirfile = new File(dir);
+    if (!dirfile.exists())
+        dirfile.mkdirs();
+    String filename = dirfile.getPath() + sep + "depend.dot";
+    Path path = Paths.get(filename);
+
+    try (Writer bw = Files.newBufferedWriter(path, StandardCharsets.UTF_8);
+         PrintWriter pw = new PrintWriter(bw, true)) {
+
+        List<String> result = createDependDotGraphBody(termDependency);
+
+        pw.println("digraph G {");
+        pw.println("  node [color=black, fontcolor=black];");
+        pw.println("  edge [color=black];");
+
+        // Top-to-bottom so heavily depended-on nodes appear higher
+        pw.println("  rankdir=BT;");
+        pw.println("  nodesep=0.35;");
+        pw.println("  ranksep=0.75;");
+
+        for (String s : result)
+            pw.println("  " + s);
+
+        pw.println("}");
+        System.out.println(createDependDotGraphImage(path.toString()));
+    }
+    catch (IOException e) {
+        String err = "Error writing file " + path + "\n" + e.getMessage();
+        System.err.println(err);
+    }
+}
 
     /** *****************************************************************
      * Make an empty KB for use in Diagnostics.

--- a/src/java/com/articulate/sigma/Diagnostics.java
+++ b/src/java/com/articulate/sigma/Diagnostics.java
@@ -753,8 +753,9 @@ public class Diagnostics {
     * @return Map<String,List<String>> a TreeMap of mutual term dependent files in the format of 
     *         Key: (LessDependentFile)>(MoreDependentFile), List<String> TermsLessDependentUsesFromMoreDependent
      */
-    private static Map<String, List<String>> mutualDependency(Map<String, Map<String, List<String>>> fileDepends) {
+    private static Map<String, List<String>> mutualDependency(KB kb) {
         
+        Map<String, Map<String, List<String>>> fileDepends = Diagnostics.termDependency(kb);
         Map<String, List<String>> mutDepends = new TreeMap<>();
         for (Map.Entry<String, Map<String, List<String>>> dependentKif : fileDepends.entrySet()) {
             Map<String, List<String>> innerMap = dependentKif.getValue();
@@ -768,6 +769,40 @@ public class Diagnostics {
             }
         }
         return mutDepends;
+    }
+
+    /** *****************************************************************
+    * This function returns a map of mutual dependencies and the terms used
+    * by the less dependent file that are defined in the more dependent file.
+    * The intended application of this function is to find the low hanging fruit 
+    * for removing mutual dependencies between files.
+    * 
+    * @param kb the knowledge base we are printing term dependency for.
+    * @param kbHref a helper String for creating clickable href links to KB term pages.
+     */
+    public static String printMutualDependencies(KB kb, String kbHref) {
+
+        Map<String, List<String>> mutDepends = Diagnostics.mutualDependency(kb);
+        StringBuilder html = new StringBuilder();
+        for (Map.Entry<String, List<String>> mutDepend : mutDepends.entrySet()) {
+            String[] fileNames = mutDepend.getKey().split(">");
+            String fileName1 = StringUtil.removeFilePath(fileNames[0]);
+            String fileName2 = StringUtil.removeFilePath(fileNames[1]);
+            if(fileName1.equals("SUMO_Cache.kif") || fileName2.equals("SUMO_Cache.kif")) continue;
+            html.append("<br/>Mutual dependency between " + fileName1 + " and " + fileName2 + ", with " + fileName1 + " using the following " + mutDepend.getValue().size() + " terms from " + fileName2 + "\n<br/>");
+            List<String> terms = mutDepend.getValue();
+            html.append("<a href=\"" + kbHref + "&term=" + terms.get(0) + "\">" + terms.get(0) + "</a>");
+            for(int i = 1; i < terms.size(); i++) {
+                String term = terms.get(i);
+                html.append(", <a href=\"" + kbHref + "&term=" + term + "\">" + term + "</a>");
+                if(i > 25) {
+                    html.append(", and " + (terms.size() - i) + " more terms.");
+                    break;
+                }
+            }
+            html.append("<br/>");
+        }
+        return html.toString();
     }
 
     /** *****************************************************************
@@ -794,6 +829,9 @@ public class Diagnostics {
      * Show file dependencies.  If two files depend on each other,
      * show only the smaller list of dependencies, under the
      * assumption that that is the erroneous set.
+     * 
+     * @param kb the knowledge base we are printing term dependency for.
+     * @param kbHref a helper String for creating clickable href links to KB term pages.
      */
     public static String printTermDependency(KB kb, String kbHref) {
 
@@ -1692,6 +1730,8 @@ public class Diagnostics {
         System.out.println("  -p - print all terms in KB");
         System.out.println("  -e - exhaustive decomposition violations");
         System.out.println("  --diff <f1> <f2> - print all terms in f2 not in f1");
+        System.out.println("  -m - mutual dependencies");
+        System.out.println("  -M - print mutual dependencies html");
         System.out.println("  -o - terms not below Entity (Orphans)");
         System.out.println("  -c - terms without documentation");
         System.out.println("  -q - quantifier not in body");
@@ -1735,11 +1775,14 @@ public class Diagnostics {
             }
             else if (argMap.containsKey("m")) {
                 System.out.println("--------------------------\nFinding Mutual Dependencies mutualDependency()...\n");
-                Map<String, List<String>> mutDepends = Diagnostics.mutualDependency(Diagnostics.termDependency(kb));
+                Map<String, List<String>> mutDepends = Diagnostics.mutualDependency(kb);
                 for(Map.Entry<String, List<String>> mutDepend : mutDepends.entrySet()) { 
                     String[] mutuallyDependentFiles = mutDepend.getKey().split(">");
                     System.out.println(StringUtil.removeFilePath(mutuallyDependentFiles[0]) + " depends on " + StringUtil.removeFilePath(mutuallyDependentFiles[1]) + " for " + mutDepend.getValue().size() + " terms");
                 }
+            }
+            else if (argMap.containsKey("M")) {
+                System.out.println("\n Printing Mutual Depencies HTML\n" + Diagnostics.printMutualDependencies(kb, ""));
             }
             else if (argMap.containsKey("D")) {
                 System.out.println("\n--------------------------\nPrinting Term Depencies to Log...\n");

--- a/src/java/com/articulate/sigma/Diagnostics.java
+++ b/src/java/com/articulate/sigma/Diagnostics.java
@@ -95,7 +95,7 @@ public class Diagnostics {
      */
     public static List termsWithoutDoc(KB kb) {
 
-        System.out.println("INFO in Diagnostics.termsWithoutDoc(): ");
+        if (debug) System.out.println("INFO in Diagnostics.termsWithoutDoc(): ");
         return termsWithoutRelation(kb,"documentation",1,' ');
     }
 
@@ -173,7 +173,7 @@ public class Diagnostics {
      */
     public static List<String> termsNotBelowEntity(KB kb) {
 
-        System.out.println("INFO in Diagnostics.termsNotBelowEntity(): ");
+        if (debug) System.out.println("INFO in Diagnostics.termsNotBelowEntity(): ");
         List<String> result = new ArrayList<>();
         int count = 0;
         String term;
@@ -200,7 +200,7 @@ public class Diagnostics {
      */
     public static List<String> partitionViolation(KB kb) {
 
-        System.out.println("Partition violations:");
+        if (debug) System.out.println("Partition violations:");
         List<String> result = new ArrayList<>();
         List<Formula> flist = kb.ask("arg",0,"partition");
         for (Formula f : flist) {
@@ -214,7 +214,7 @@ public class Diagnostics {
                     if (!subs.contains(newSub)) {
                         String s = "Error in partitionViolation(): " + subf +
                                 " not part of " + f;
-                        System.out.println(s);
+                        if (debug) System.out.println(s);
                         result.add(s);
                     }
                 }
@@ -697,7 +697,8 @@ public class Diagnostics {
      */
     private static Map<String,Map<String,List<String>>> termDependency(KB kb) {
 
-        System.out.println("INFO in Diagnostics.termDependency()");
+        debug = true;
+        if (debug) System.out.println("INFO in Diagnostics.termDependency()");
 
         // A map of terms keys with an ArrayList as values listing files
         // in which the term is used.
@@ -780,7 +781,7 @@ public class Diagnostics {
         // on which the given file depends.  The interior TreeMap file name
         // keys index ArrayLists of terms.  file -depends on-> filenames -that defines-> terms
         Map<String,Map<String,List<String>>> fileDepends = Diagnostics.termDependency(kb);
-        System.out.println(fileDepends);
+        if (debug) System.out.println("Diagnostics.printTermDependency(): fileDepends /n" + fileDepends);
         Map<String,List<String>> tm;
         List<String> al;
         String term;
@@ -871,8 +872,7 @@ private static List<String> createDependDotGraphBody(Map<String,Map<String,List<
         if (nameOnly.equals("SUMO_Cache"))
             continue;
 
-        if (debug)
-            System.out.println("createDependDotGraphBody(): file = " + filename);
+        if (debug) System.out.println("createDependDotGraphBody(): file = " + filename);
 
         nodes.add(nameOnly);
         incomingCounts.putIfAbsent(nameOnly, 0);
@@ -962,7 +962,7 @@ public static String createDependDotGraphImage(String filename) throws IOExcepti
     cmd.add("-T" + imageExt);
     cmd.add("-O");
     cmd.add(filename);
-    System.out.println(cmd);
+    if (debug) System.out.println(cmd);
     try {
         // Build a dependency graph image from an input file
         // From: https://graphviz.org/doc/info/command.html#-O
@@ -1019,7 +1019,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
             pw.println("  " + s);
 
         pw.println("}");
-        System.out.println(createDependDotGraphImage(path.toString()));
+        if (debug) System.out.println(createDependDotGraphImage(path.toString()));
     }
     catch (IOException e) {
         String err = "Error writing file " + path + "\n" + e.getMessage();
@@ -1043,7 +1043,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
         String emptyCFilename = emptyCFile.getAbsolutePath();
         KBmanager.getMgr().addKB(kbName);
         KB empty = KBmanager.getMgr().getKB(kbName);
-        System.out.println("empty = " + empty);
+        if (debug) System.out.println("empty = " + empty);
 
         // Fails elsewhere if no constituents, or empty constituent, thus...
         try (Writer fw = new FileWriter( emptyCFile );
@@ -1115,7 +1115,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
         StringBuilder answer = new StringBuilder();
         KB empty = makeEmptyKB("consistencyCheck");
 
-        System.out.println("=================== Consistency Testing ===================");
+        if (debug) System.out.println("=================== Consistency Testing ===================");
         try {
             FormulaPreprocessor fp;
             String processedQuery;
@@ -1128,11 +1128,11 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                 //System.out.println(" query = " + query);
                 //System.out.println(" processedQueries = " + processedQueries);
 
-                System.out.println("INFO in Diagnostics.kbConsistencyCheck(): size = " + processedQueries.size());
+                if (debug) System.out.println("INFO in Diagnostics.kbConsistencyCheck(): size = " + processedQueries.size());
                 for (Formula f : processedQueries) {
-                    System.out.println("INFO in Diagnostics.kbConsistencyCheck(): formula = " + f.getFormula());
+                    if (debug) System.out.println("INFO in Diagnostics.kbConsistencyCheck(): formula = " + f.getFormula());
                     processedQuery = f.makeQuantifiersExplicit(false);
-                    System.out.println("INFO in Diagnostics.kbConsistencyCheck(): processedQuery = " + processedQuery);
+                    if (debug) System.out.println("INFO in Diagnostics.kbConsistencyCheck(): processedQuery = " + processedQuery);
                     proof = empty.askEProver(processedQuery,timeout,maxAnswers) + " ";
                     a = new StringBuilder();
                     a.append(reportAnswer(kb,proof,query,processedQuery,"Redundancy"));
@@ -1182,14 +1182,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                     tformstrs.add(str);
                 }
                 simpleName = fname.substring(fname.lastIndexOf('/')+1,fname.length());
-                System.out.print(t + "\t" + simpleName + "\t");
+                if (debug) System.out.print(t + "\t" + simpleName + "\t");
                 int i = 0;
                 for (String st : tformstrs) {
                     if (i < 3)
-                        System.out.print(st + "\t");
+                        if (debug) System.out.print(st + "\t");
                     i++;
                 }
-                System.out.println();
+                if (debug) System.out.println();
             }
         }
     }
@@ -1199,7 +1199,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
      */
     public static void termDefsByGivenFile(KB kb, Set<String> files) {
 
-        System.out.println("termDefsByGivenFile(): files: " + files);
+        if (debug) System.out.println("termDefsByGivenFile(): files: " + files);
         Set<String> alreadyCounted = new HashSet<>();
         Map<String,Set<String>> termsByFile = new HashMap<>();
         String fname, simpleName, str;
@@ -1254,14 +1254,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                     str = f.getStringArgument(3);
                     tformstrs.add(str);
                 }
-                System.out.print(term + "\t" + fnam + "\t");
+                if (debug) System.out.print(term + "\t" + fnam + "\t");
                 int i = 0;
                 for (String st : tformstrs) {
                     if (i < 3)
-                        System.out.print(st + "\t");
+                        if (debug) System.out.print(st + "\t");
                     i++;
                 }
-                System.out.println();
+                if (debug) System.out.println();
             }
         }
     }
@@ -1282,14 +1282,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                 str = f.getStringArgument(3);
                 tformstrs.add(str);
             }
-            System.out.print(term + "\t");
+            if (debug) System.out.print(term + "\t");
             i = 0;
             for (String st : tformstrs) {
                 if (i < 3)
-                    System.out.print(st + "\t");
+                    if (debug) System.out.print(st + "\t");
                 i++;
             }
-            System.out.println();
+            if (debug) System.out.println();
         }
     }
 
@@ -1298,7 +1298,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
     public static void printAllTerms(KB kb) {
 
         for (String t : kb.terms)
-            System.out.println(t);
+            if (debug) System.out.println(t);
     }
 
     /** ***************************************************************
@@ -1337,14 +1337,14 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                 str = f.getStringArgument(3);
                 tformstrs.add(str);
             }
-            System.out.print(term + "\t"); //  + fname + "\t");
+            if (debug) System.out.print(term + "\t"); //  + fname + "\t");
             int i = 0;
             for (String st : tformstrs) {
                 if (i < 3)
-                    System.out.print(st + "\t");
+                    if (debug) System.out.print(st + "\t");
                 i++;
             }
-            System.out.println();
+            if (debug) System.out.println();
         }
     }
 
@@ -1673,8 +1673,8 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
                     // a variable appearing multiple times, e.g., on both sides of an implication is intentional usage, not an orphan
                     int count = countOccurrences(f.getFormula(), var);
                     if (count == 1) {
-                        System.out.println("\nWARNING in formula: " + f.getFormula());
-                        System.out.println("  Orphan variable found: " + var);
+                        if (debug) System.out.println("\nWARNING in formula: " + f.getFormula());
+                        if (debug) System.out.println("  Orphan variable found: " + var);
                         hasOrphans = true;
                         foundAnyWarnings = true;
                     }
@@ -1684,10 +1684,10 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
             if (!hasOrphans && !map.isEmpty()) {
                 ArrayList<HashSet<String>> groups = findDisconnectedGroups(map);
                 if (groups.size() > 1) {
-                    System.out.println("\nWARNING in formula: " + f.getFormula());
-                    System.out.println("  Formula has " + groups.size() + " variable groups that are disconnected from each other:");
+                    if (debug) System.out.println("\nWARNING in formula: " + f.getFormula());
+                    if (debug) System.out.println("  Formula has " + groups.size() + " variable groups that are disconnected from each other:");
                     for (int i = 0; i < groups.size(); i++) {
-                        System.out.println("    Group " + (i + 1) + ": " + groups.get(i));
+                        if (debug) System.out.println("    Group " + (i + 1) + ": " + groups.get(i));
                     }
                     foundAnyWarnings = true;
                 }
@@ -1695,7 +1695,7 @@ public static void createDependDotGraph(Map<String,Map<String,List<String>>> ter
             mergeResults(links, map);
         }
         if (!foundAnyWarnings) {
-            System.out.println("\nNo variable connectivity issues found.");
+            if (debug) System.out.println("\nNo variable connectivity issues found.");
         }
         return links;
     }

--- a/src/java/com/articulate/sigma/Diagnostics.java
+++ b/src/java/com/articulate/sigma/Diagnostics.java
@@ -613,7 +613,7 @@ public class Diagnostics {
 
         List<String> definitionalRelations = Arrays.asList("instance", "subclass",
                 "subAttribute", "domain", "domainSubclass", "range",
-                "rangeSubclass", "documentation", "subrelation");
+                "rangeSubclass", "subrelation");
 
         List<Formula> forms, newform;
         String relation, filename;

--- a/src/java/com/articulate/sigma/Diagnostics.java
+++ b/src/java/com/articulate/sigma/Diagnostics.java
@@ -697,8 +697,6 @@ public class Diagnostics {
      */
     private static Map<String,Map<String,List<String>>> termDependency(KB kb) {
 
-        System.out.println("INFO in Diagnostics.termDependency()");
-
         // A map of terms keys with an ArrayList as values listing files
         // in which the term is used.
         Map<String,List<String>> termsUsed = new TreeMap<>();
@@ -720,6 +718,7 @@ public class Diagnostics {
         // A map of file name keys and TreeMap values listing file names
         // on which the given file depends.  The interior TreeMap file name
         // keys index ArrayLists of terms.  file -depends on-> filenames -that defines-> terms
+        //  dependentFile, dependeeFile, Terms
         Map<String,Map<String,List<String>>> fileDepends = new TreeMap<>();
 
         termLinks(kb,termsUsed,termsDefined);
@@ -742,6 +741,33 @@ public class Diagnostics {
             }
         }
         return fileDepends;
+    }
+
+    /** *****************************************************************
+    * This function returns a map of mutual dependencies and the terms used
+    * by the less dependent file that are defined in the more dependent file.
+    * The intended application of this function is to find the low hanging fruit 
+    * for removing mutual dependencies between files.
+    * 
+    * @param Map<String,Map<String,List<String>>> fileDepends <Dependent, <Dependees, Terms>>
+    * @return Map<String,List<String>> a TreeMap of mutual term dependent files in the format of 
+    *         Key: (LessDependentFile)>(MoreDependentFile), List<String> TermsLessDependentUsesFromMoreDependent
+     */
+    private static Map<String, List<String>> mutualDependency(Map<String, Map<String, List<String>>> fileDepends) {
+        
+        Map<String, List<String>> mutDepends = new TreeMap<>();
+        for (Map.Entry<String, Map<String, List<String>>> dependentKif : fileDepends.entrySet()) {
+            Map<String, List<String>> innerMap = dependentKif.getValue();
+            for (Map.Entry<String, List<String>> dependeeKif : innerMap.entrySet()) {
+                if(fileDepends.containsKey(dependeeKif.getKey()) 
+                    && fileDepends.get(dependeeKif.getKey()).containsKey(dependentKif.getKey())
+                    && dependeeKif.getValue().size() < fileDepends.get(dependeeKif.getKey()).get(dependentKif.getKey()).size()
+                    ) {
+                    mutDepends.put(dependentKif.getKey() + ">" + dependeeKif.getKey(), dependeeKif.getValue());
+                }
+            }
+        }
+        return mutDepends;
     }
 
     /** *****************************************************************
@@ -780,7 +806,7 @@ public class Diagnostics {
         // on which the given file depends.  The interior TreeMap file name
         // keys index ArrayLists of terms.  file -depends on-> filenames -that defines-> terms
         Map<String,Map<String,List<String>>> fileDepends = Diagnostics.termDependency(kb);
-        System.out.println(fileDepends);
+
         Map<String,List<String>> tm;
         List<String> al;
         String term;
@@ -847,6 +873,8 @@ public class Diagnostics {
         }
         return result.toString();
     }
+
+
 
     /***************************************************************
      * @param termDependency a TreeMap of file name keys and an ArrayList of the
@@ -1704,6 +1732,29 @@ public class Diagnostics {
             }
             else if (argMap.containsKey("o")) {
                 System.out.println(termsNotBelowEntity(kb));
+            }
+            else if (argMap.containsKey("m")) {
+                System.out.println("--------------------------\nFinding Mutual Dependencies mutualDependency()...\n");
+                Map<String, List<String>> mutDepends = Diagnostics.mutualDependency(Diagnostics.termDependency(kb));
+                for(Map.Entry<String, List<String>> mutDepend : mutDepends.entrySet()) { 
+                    String[] mutuallyDependentFiles = mutDepend.getKey().split(">");
+                    System.out.println(StringUtil.removeFilePath(mutuallyDependentFiles[0]) + " depends on " + StringUtil.removeFilePath(mutuallyDependentFiles[1]) + " for " + mutDepend.getValue().size() + " terms");
+                }
+            }
+            else if (argMap.containsKey("D")) {
+                System.out.println("\n--------------------------\nPrinting Term Depencies to Log...\n");
+                Map<String,Map<String,List<String>>> fileDepends = Diagnostics.termDependency(kb);
+                for (Map.Entry<String, Map<String, List<String>>> outerEntry : fileDepends.entrySet()) {
+                    Map<String, List<String>> innerMap = outerEntry.getValue();
+                    for (Map.Entry<String, List<String>> innerEntry : innerMap.entrySet()) {
+                        List<String> values = innerEntry.getValue();
+                        String dependent = StringUtil.removeFilePath(outerEntry.getKey());
+                        String dependee = StringUtil.removeFilePath(innerEntry.getKey());
+                        if (!dependent.equals("SUMO_Cache.kif") && !dependee.equals("SUMO_Cache.kif"))
+                            System.out.println(dependent + " uses " + values.size() + " terms defined in " + dependee);
+                    }
+                    System.out.println();
+                }
             }
             else if (argMap.containsKey("c")) {
                 System.out.println(termsWithoutDoc(kb));

--- a/src/java/com/articulate/sigma/Diagnostics.java
+++ b/src/java/com/articulate/sigma/Diagnostics.java
@@ -857,15 +857,18 @@ public class Diagnostics {
         String line;
         for (String filename : termDependency.keySet()) {
             String nameOnly = sanitizeFilenameForGraphViz(filename);
-            if (debug) System.out.println("createDependDotGraphBody()" + filename);
-            String newline = nameOnly + " [shape=\"box\" label = < " + nameOnly +
-                    " <br align=\"left\"/> > ]";
-            lines.add(newline);
-            if (termDependency.get(filename) != null) {
-                for (String otherFile : termDependency.get(filename).keySet()) {
-                    String otherNameOnly = sanitizeFilenameForGraphViz(otherFile);
-                    line = nameOnly + " -> " + otherNameOnly + "; ";
-                    lines.add(line);
+            if(!nameOnly.equals("SUMO_Cache")) {
+                if (debug) System.out.println("createDependDotGraphBody()" + filename);
+                String newline = nameOnly + " [shape=\"box\" label = < " + nameOnly + " <br align=\"left\"/> > ]";
+                lines.add(newline);
+                if (termDependency.get(filename) != null) {
+                    for (String otherFile : termDependency.get(filename).keySet()) {
+                        String otherNameOnly = sanitizeFilenameForGraphViz(otherFile);
+                        if(!otherNameOnly.equals("SUMO_Cache")) {
+                            line = nameOnly + " -> " + otherNameOnly + "; ";
+                            lines.add(line);
+                        }
+                    }
                 }
             }
         }

--- a/src/java/com/articulate/sigma/KBcache.java
+++ b/src/java/com/articulate/sigma/KBcache.java
@@ -715,11 +715,11 @@ public class KBcache implements Serializable {
     public int getArity(String rel) {
 
         if (valences == null) {
-            System.err.println("Error in KBcache.getArity(): null valences");
+            if (debug) System.err.println("Error in KBcache.getArity(): null valences");
             return 0;
         }
         if (!valences.containsKey(rel)) {
-            System.err.println("Error in KBcache.getArity(): " + rel + " not found");
+            if (debug) System.err.println("Error in KBcache.getArity(): " + rel + " not found");
             return 0;
         }
         return valences.get(rel);
@@ -731,7 +731,7 @@ public class KBcache implements Serializable {
     private void arrayListReplace(List<String> al, int index, String newEl) {
 
         if (index > al.size()) {
-            System.err.println("Error in KBcache.arrayListReplace(): index " + index +
+            if (debug) System.err.println("Error in KBcache.arrayListReplace(): index " + index +
                     " out of bounds.");
             return;
         }
@@ -913,7 +913,7 @@ public class KBcache implements Serializable {
             sig.add("Entity");
         }
         if (sig == null)
-            System.err.println("Error in KBcache.extendInstance(): no sig for term " + term);
+            if (debug) System.err.println("Error in KBcache.extendInstance(): no sig for term " + term);
         List<String> newsig = SUMOtoTFAform.relationExtractSigFromName(newTerm);
         signatures.put(newTerm,newsig);
         // The number of arguments to each relation.  Variable arity is -1
@@ -1134,18 +1134,18 @@ public class KBcache implements Serializable {
         if (!StringUtil.emptyString(c1) && !StringUtil.emptyString(c2) && c1.endsWith("+") && !c2.endsWith("+") && !c2.endsWith("Class")) {
             String err = "KBcache.checkDisjoint(): mixing class and instance: " + c1 + ", " + c2;
             errors.add(err);
-            System.err.println(err);
+            if (debug) System.err.println(err);
             return true;
         }
         if (!StringUtil.emptyString(c1) && !StringUtil.emptyString(c2) && c2.endsWith("+") && !c1.endsWith("+") && !c1.endsWith("Class")) {
             String err = "KBcache.checkDisjoint(): mixing class and instance: " + c1 + ", " + c2;
-            System.err.println(err);
+            if (debug) System.err.println(err);
             errors.add(err);
             return true;
         }
         if (disjoint.contains(c1 + "\t" + c2) || disjoint.contains(c2 + "\t" + c1)) {
             String err = "KBcache.checkDisjoint(): disjoint classes: " + c1 + ", " + c2;
-            System.err.println(err);
+            if (debug) System.err.println(err);
             errors.add(err);
             return true;
         }
@@ -1265,7 +1265,7 @@ public class KBcache implements Serializable {
         for (String cl : p1) {
             classes = subclasses.get(cl);
             if (classes == null)
-                System.err.println("Error in KBcache.mostSpecificParent(): no subclasses for : " + cl);
+                if (debug) System.err.println("Error in KBcache.mostSpecificParent(): no subclasses for : " + cl);
             else {
                 count = classes.size();
                 countString = Integer.toString(count);
@@ -1640,7 +1640,7 @@ public class KBcache implements Serializable {
 
         Map<String,Set<String>> relParents = parents.get(rel);
         if (relParents == null) {
-            System.err.println("Error in KBcache.breadthFirstBuildParents(): no relation " + rel);
+            if (debug) System.err.println("Error in KBcache.breadthFirstBuildParents(): no relation " + rel);
             return;
         }
         int threshold = 10;      // maximum time that a term can be traversed in breadthFirstBuildParents()
@@ -1690,7 +1690,7 @@ public class KBcache implements Serializable {
 
         Map<String,Set<String>> relChildren = children.get(rel);
         if (relChildren == null) {
-            System.err.println("Error in KBcache.breadthFirstBuildChildren(): no relation " + rel);
+            if (debug) System.err.println("Error in KBcache.breadthFirstBuildChildren(): no relation " + rel);
             return;
         }
         //if (debug) System.out.println("INFO in KBcache.breadthFirstBuildChildren(): trying relation " + rel);
@@ -1904,7 +1904,7 @@ public class KBcache implements Serializable {
                     if (debug) System.out.println("INFO in KBcache.collectDomains(): form " + form);
                     arg2 = form.getStringArgument(2);
                     if (StringUtil.emptyString(arg2) || !StringUtil.isNumeric(arg2)) {
-                        System.err.println("Error in KBcache.collectDomains(): arg2 not a number in:  " + form);
+                        if (debug) System.err.println("Error in KBcache.collectDomains(): arg2 not a number in:  " + form);
                         continue;
                     }
                     arg = Integer.parseInt(form.getStringArgument(2));
@@ -1970,8 +1970,8 @@ public class KBcache implements Serializable {
         String rel = "subrelation";
         Map<String,Set<String>> relParents = parents.get("subrelation");
         if (relParents == null) {
-            System.err.println("Error in KBcache.breadthFirstInheritDomains(): no parents using relation subrelation");
-            System.err.println(parents);
+            if (debug) System.err.println("Error in KBcache.breadthFirstInheritDomains(): no parents using relation subrelation");
+            if (debug) System.err.println(parents);
             return;
         }
         Deque<String> Q = new ArrayDeque<>();
@@ -1990,7 +1990,7 @@ public class KBcache implements Serializable {
                     newDomains = signatures.get(newTerm);
                     if (debug) System.out.println("KBcache.breadthFirstInheritDomains(); newDomains: " + newDomains);
                     if (valences.get(t) == null) {
-                        System.err.println("Error in KBcache.breadthFirstInheritDomains(): no valence for " + t);
+                        if (debug) System.err.println("Error in KBcache.breadthFirstInheritDomains(): no valence for " + t);
                         continue;
                     }
                     else if (valences.get(newTerm) == null || valences.get(newTerm) < valences.get(t)) {
@@ -2116,14 +2116,14 @@ public class KBcache implements Serializable {
         try (Reader r = new StringReader(sb.toString())) {
             kif.parse(r);
         } catch (IOException ioe) {
-            System.err.println("Error in KBcache.storeCacheAsFormulas(): " + ioe.getMessage());
+            if (debug) System.err.println("Error in KBcache.storeCacheAsFormulas(): " + ioe.getMessage());
             return;
         }
         if (KBmanager.getMgr().getPref("cache").equals("yes"))
             kb.addConstituentInfo(kif);
 
-        System.out.printf("KBcache.storeCacheAsFormulas(): done creating cache formulas, in %d m/s%n", (System.currentTimeMillis() - millis));
-        System.out.printf("KBcache.storeCacheAsFormulas(): cached statements: %d%n", cacheCount);
+        if (debug) System.out.printf("KBcache.storeCacheAsFormulas(): done creating cache formulas, in %d m/s%n", (System.currentTimeMillis() - millis));
+        if (debug) System.out.printf("KBcache.storeCacheAsFormulas(): cached statements: %d%n", cacheCount);
     }
 
     /** ***************************************************************
@@ -2152,7 +2152,7 @@ public class KBcache implements Serializable {
             instrel = true;
             sig = signatures.get(rel);
             if (sig == null)
-                System.err.println("Error in KBcache.buildInstTransRels(): Error " + rel + " not found.");
+                if (debug) System.err.println("Error in KBcache.buildInstTransRels(): Error " + rel + " not found.");
             else {
                 for (int i = 0; i < sig.size(); i++) {
                     signatureElement = sig.get(i);
@@ -2253,7 +2253,7 @@ public class KBcache implements Serializable {
             try {
                 f.get(); // waits for task completion
             } catch (InterruptedException | ExecutionException ex) {
-                System.err.printf("Error in KBcache.buildCaches(): %s%n", ex.getMessage());
+                if (debug) System.err.printf("Error in KBcache.buildCaches(): %s%n", ex.getMessage());
                 ex.printStackTrace();
             }
 
@@ -2375,7 +2375,7 @@ public class KBcache implements Serializable {
 
         List<String> sig = getSignature(r);
         if (sig == null)
-            System.err.println("Error in variableArityType() null signature for " + r);
+            if (debug) System.err.println("Error in variableArityType() null signature for " + r);
         String type = sig.get(sig.size() - 1);
         return type;
     }

--- a/src/java/com/articulate/sigma/KButilities.java
+++ b/src/java/com/articulate/sigma/KButilities.java
@@ -55,6 +55,7 @@ public class KButilities implements ServletContextListener {
     private static volatile ExecutorService currentExecutorService;
     private static final Object executorLock = new Object();
     private static volatile boolean isJEditMode = false;
+    public static boolean debug = false;
 
     // Create the appropriate ExecutorService based on context
     private static ExecutorService createExecutorService() {
@@ -72,7 +73,7 @@ public class KButilities implements ServletContextListener {
 
         if (isJEditMode) {
             // For jEdit: use single-threaded executor to prevent deadlocks
-            System.out.println("KButilities: Creating single-threaded executor for jEdit mode");
+            if(debug) if (debug) System.out.println("KButilities: Creating single-threaded executor for jEdit mode");
             return Executors.newSingleThreadExecutor(r -> {
                 Thread t = new Thread(r, "SIGMA-jEdit-Thread");
                 t.setDaemon(true); // Make it daemon to ensure JVM exits cleanly
@@ -80,7 +81,7 @@ public class KButilities implements ServletContextListener {
             });
         } else {
             // For translation: use fixed thread pool for predictable performance
-            System.out.println("KButilities: Creating fixed thread pool (" + PAR + " threads) for translation mode");
+            if (debug) System.out.println("KButilities: Creating fixed thread pool (" + PAR + " threads) for translation mode");
             return Executors.newFixedThreadPool(PAR, r -> {
                 Thread t = new Thread(r, "SIGMA-Translation-Thread");
                 t.setDaemon(true); // Make it daemon to ensure JVM exits cleanly
@@ -207,12 +208,10 @@ public class KButilities implements ServletContextListener {
         final String msg = (env == null || env.isEmpty())
                 ? "SIGMA_HOME not set in environment; defaulting to " + SIGMA_HOME
                 : "SIGMA_HOME set to " + SIGMA_HOME;
-        System.out.println("[KButilities] " + msg);
+        if(debug) if (debug) System.out.println("[KButilities] " + msg);
     }
 
     public static final int ONE_K = 1000;
-
-    public static boolean debug = false;
 
     /** Errors found during processing formulas */
     public static Set<String> errors = new TreeSet<>();
@@ -311,14 +310,14 @@ public class KButilities implements ServletContextListener {
         String error;
         if (SUMOtoTFAform.inconsistentVarTypes()) {
             error = "inconsistent types in " + SUMOtoTFAform.getVarmap();
-            System.err.println("hasCorrectTypes(): " + error);
+            if (debug) System.err.println("hasCorrectTypes(): " + error);
             errors.addAll(SUMOtoTFAform.errors);
             SUMOtoTFAform.errors.clear();
             return false;
         }
         if (SUMOtoTFAform.typeConflict(f)) {
             error = "Type conflict: " + SUMOtoTFAform.errors;
-            System.err.println("hasCorrectTypes(): " + error);
+            if (debug) System.err.println("hasCorrectTypes(): " + error);
             errors.addAll(SUMOtoTFAform.errors);
             SUMOtoTFAform.errors.clear();
             return false;
@@ -357,7 +356,7 @@ public class KButilities implements ServletContextListener {
             String error = "Formula rejected due to arity error of predicate " + term
                     + " in formula: \n" + f.getFormula();
             errors.add(error);
-            if (debug) System.err.println("isValidFormula(): Error: " + error);
+            if (debug) if (debug) System.err.println("isValidFormula(): Error: " + error);
             return false;
         }
         if (!hasCorrectTypes(kb,f))
@@ -477,7 +476,7 @@ public class KButilities implements ServletContextListener {
         for (List<String> row : spread) {
             if (row != null && row.size() > 1) {
                 label = row.get(termcol);
-                System.out.println("(synonymousExternalConcept \"" + label + "\" Entity Taxonomy)");
+                if (debug) System.out.println("(synonymousExternalConcept \"" + label + "\" Entity Taxonomy)");
             }
         }
     }
@@ -533,7 +532,7 @@ public class KButilities implements ServletContextListener {
      */
     public static void countRelations(KB kb) {
 
-        System.out.println("Relations: " + kb.getCountRelations());
+        if (debug) System.out.println("Relations: " + kb.getCountRelations());
         Iterator it = kb.terms.iterator();
         String term;
         List al;
@@ -541,7 +540,7 @@ public class KButilities implements ServletContextListener {
             term = (String) it.next();
             al = kb.ask("arg",0,term);
             if (al != null && !al.isEmpty()) {
-                System.out.println(term + " " + al.size());
+                if (debug) System.out.println(term + " " + al.size());
             }
         }
     }
@@ -568,8 +567,8 @@ public class KButilities implements ServletContextListener {
                     wncount += WordNet.wn.SUMOHash.get(term).size();
             }
         }
-        System.out.println("SUMO Process subclass count: " + count);
-        System.out.println("SUMO Process synsets: " + wncount);
+        if (debug) System.out.println("SUMO Process subclass count: " + count);
+        if (debug) System.out.println("SUMO Process synsets: " + wncount);
     }
 
     /** *************************************************************
@@ -602,7 +601,7 @@ public class KButilities implements ServletContextListener {
             f = (Formula) results.get(i);
             url = StringUtil.removeEnclosingQuotes(f.getStringArgument(2));
             if (!uRLexists(url))
-                System.err.println(f + " doesn't exist");
+                if (debug) System.err.println(f + " doesn't exist");
         }
     }
 
@@ -628,18 +627,18 @@ public class KButilities implements ServletContextListener {
                 m = p.matcher(line);
                 if (m.matches()) {
                     url = StringUtil.removeEnclosingQuotes(m.group(3));
-                    //System.out.println("the url: " + url);
+                    //if (debug) System.out.println("the url: " + url);
                     if (!uRLexists(url))
-                        System.out.println(";; " + line);
+                        if (debug) System.out.println(";; " + line);
                     else
-                        System.out.println(line);
+                        if (debug) System.out.println(line);
                 }
                 else
-                    System.out.println(line);
+                    if (debug) System.out.println(line);
             }
         }
         catch (IOException e) {
-            System.err.println("Error reading pictureList.kif\n" + e.getMessage());
+            if (debug) System.err.println("Error reading pictureList.kif\n" + e.getMessage());
         }
     }
 
@@ -785,11 +784,11 @@ public class KButilities implements ServletContextListener {
                 }
             }
         }
-        //System.out.println("generateSemNetNeighbors(): before recursion: " + resultSet);
+        //if (debug) System.out.println("generateSemNetNeighbors(): before recursion: " + resultSet);
         if (count > 0)
             for (String s : targets)
                 resultSet.addAll(generateSemNetNeighbors(kb,cached,strings,links,s,count-1));
-        //System.out.println("generateSemNetNeighbors(): returning: " + resultSet);
+        //if (debug) System.out.println("generateSemNetNeighbors(): returning: " + resultSet);
         return resultSet;
     }
 
@@ -838,7 +837,7 @@ public class KButilities implements ServletContextListener {
                     arg1 = f.getStringArgument(1);
                     arg2 = f.getStringArgument(2);
                     if (arg1.contains(Formula.LP) || arg1.contains(Formula.RP) || arg2.contains(Formula.LP) || arg2.contains(Formula.RP))
-                        System.out.println("error in generateSemanticNetwork(): for formula: " + f);
+                        if (debug) System.out.println("error in generateSemanticNetwork(): for formula: " + f);
                     else if (!Formula.isLogicalOperator(arg1) && !Formula.isLogicalOperator(arg2) &&
                             !Formula.isVariable(arg1) && !Formula.isVariable(arg1) &&
                             (strings || !StringUtil.isQuotedString(arg1)) && (strings || !StringUtil.isQuotedString(arg2)))
@@ -974,7 +973,7 @@ public class KButilities implements ServletContextListener {
             edgepw.print(sb.toString());
         }
         catch (IOException e) {
-            System.err.println(e.getMessage());
+            if (debug) System.err.println(e.getMessage());
             e.printStackTrace();
         }
     }
@@ -1018,7 +1017,7 @@ public class KButilities implements ServletContextListener {
             }
         }
         catch (Exception e) {
-            System.err.println(e.getMessage());
+            if (debug) System.err.println(e.getMessage());
             e.printStackTrace();
         }
     }
@@ -1067,7 +1066,7 @@ public class KButilities implements ServletContextListener {
             edgepw.print(sb.toString());
         }
         catch (IOException e) {
-            System.err.println(e.getMessage());
+            if (debug) System.err.println(e.getMessage());
             e.printStackTrace();
         }
     }
@@ -1188,7 +1187,7 @@ public class KButilities implements ServletContextListener {
             }
         }
         catch (IOException e) {
-            System.err.println(e.getMessage());
+            if (debug) System.err.println(e.getMessage());
             e.printStackTrace();
         }
     }
@@ -1199,10 +1198,10 @@ public class KButilities implements ServletContextListener {
 
         try {
             int counter = 0;
-            System.out.println("INFO in KB.generateTPTPTestAssertions()");
+            if (debug) System.out.println("INFO in KB.generateTPTPTestAssertions()");
             KBmanager.getMgr().initializeOnce();
             KB kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname"));
-            System.out.println("INFO in KB.generateTPTPTestAssertions(): printing predicates");
+            if (debug) System.out.println("INFO in KB.generateTPTPTestAssertions(): printing predicates");
             String argType1, argType2;
             for (String term : kb.terms) {
                 if (Character.isLowerCase(term.charAt(0)) && kb.kbCache.valences.get(term) <= 2) {
@@ -1212,23 +1211,23 @@ public class KButilities implements ServletContextListener {
                         String argnum = forms.get(i).getArgument(2);
                         String type = forms.get(i).getArgument(3);
                         if (argnum.equals("1"))
-                            System.out.print("(instance Foo " + type + "),");
+                            if (debug) System.out.print("(instance Foo " + type + "),");
                         if (argnum.equals("2"))
-                            System.out.print("(instance Bar " + type + Formula.RP);
+                            if (debug) System.out.print("(instance Bar " + type + Formula.RP);
                     }
                     */
                     argType1 = kb.getArgType(term,1);
                     argType2 = kb.getArgType(term,2);
                     if (argType1 != null && argType2 != null) {
-                        System.out.print("fof(local_" + counter++ + ",axiom,(s__" + term + "(s__Foo,s__Bar))).|");
-                        System.out.print("fof(local_" + counter++ + ",axiom,(s__instance(s__Foo,s__" + argType1 + "))).|");
-                        System.out.println("fof(local_" + counter++ + ",axiom,(s__instance(s__Bar,s__" + argType2 + "))).");
+                        if (debug) System.out.print("fof(local_" + counter++ + ",axiom,(s__" + term + "(s__Foo,s__Bar))).|");
+                        if (debug) System.out.print("fof(local_" + counter++ + ",axiom,(s__instance(s__Foo,s__" + argType1 + "))).|");
+                        if (debug) System.out.println("fof(local_" + counter++ + ",axiom,(s__instance(s__Bar,s__" + argType2 + "))).");
                     }
                 }
             }
         }
         catch (Exception e) {
-            System.err.println(e.getMessage());
+            if (debug) System.err.println(e.getMessage());
         }
     }
 
@@ -1238,17 +1237,17 @@ public class KButilities implements ServletContextListener {
     public static void generateRelationList() {
 
         try {
-            System.out.println("INFO in KB.generateRelationList()");
+            if (debug) System.out.println("INFO in KB.generateRelationList()");
             KBmanager.getMgr().initializeOnce();
             KB kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname"));
-            System.out.println("INFO in KB.generateRelationList(): printing predicates");
+            if (debug) System.out.println("INFO in KB.generateRelationList(): printing predicates");
             for (String term : kb.terms) {
                 if (Character.isLowerCase(term.charAt(0)))
-                    System.out.println(term);
+                    if (debug) System.out.println(term);
             }
         }
         catch (Exception e) {
-            System.err.println(e.getMessage());
+            if (debug) System.err.println(e.getMessage());
         }
     }
 
@@ -1276,7 +1275,7 @@ public class KButilities implements ServletContextListener {
     public static void countStringWords(KB kb) {
 
         int total = 0;
-        System.out.println("INFO in KB.countStringWords(): counting words");
+        if (debug) System.out.println("INFO in KB.countStringWords(): counting words");
         Pattern p;
         Matcher m;
         boolean b;
@@ -1293,11 +1292,11 @@ public class KButilities implements ServletContextListener {
                     if (ar[i].matches("\\w+"))
                         total++;
                 }
-                System.out.println(quoted);
-                System.out.println(ar.length);
+                if (debug) System.out.println(quoted);
+                if (debug) System.out.println(ar.length);
             }
         }
-        System.out.println(total);
+        if (debug) System.out.println(total);
     }
 
     /** *************************************************************
@@ -1381,14 +1380,14 @@ public class KButilities implements ServletContextListener {
      */
     public static void genDoc(KB kb, String fname) {
 
-        System.out.println(genDocHeader(true));
+        if (debug) System.out.println(genDocHeader(true));
         List<Formula> al = kb.ask("arg",0,"documentation");
         for (Formula form : al) {
             String arg;
             if (form.sourceFile.endsWith(fname)) {
                 arg = form.getArgument(3).toString();
                 arg = arg.replace("&%","");
-                System.out.println(form.getArgument(1) + "\t" + arg);
+                if (debug) System.out.println(form.getArgument(1) + "\t" + arg);
             }
         }
     }
@@ -1438,7 +1437,7 @@ public class KButilities implements ServletContextListener {
                 files.put(s,pw);
             }
             catch (Exception e) {
-                System.err.println(e.getMessage());
+                if (debug) System.err.println(e.getMessage());
                 e.printStackTrace();
             }
         }
@@ -1559,22 +1558,22 @@ public class KButilities implements ServletContextListener {
      */
     public static void genAllHTMLDoc(KB kb) {
 
-        System.out.println("<h2>Data Dictionary</h2>");
-        System.out.println("<table><tr><th style:\"width:20%\"><b>Term</b></th><th style=\"width:75%\"><b>Doc</b></th></tr>\n");
+        if (debug) System.out.println("<h2>Data Dictionary</h2>");
+        if (debug) System.out.println("<table><tr><th style:\"width:20%\"><b>Term</b></th><th style=\"width:75%\"><b>Doc</b></th></tr>\n");
         Map<String,String> map = genDocList(kb);
         boolean shade = false;
         String arg2;
         for (String term : map.keySet()) {
             arg2 = map.get(term);
             if (shade)
-                System.out.println("<tr bgcolor=\"#ddd\"><td>");
+                if (debug) System.out.println("<tr bgcolor=\"#ddd\"><td>");
             else
-                System.out.println("<tr><td>");
+                if (debug) System.out.println("<tr><td>");
             // (KB kb, String term, String lang, String doc, boolean noSUMO, boolean coreTerm)
-            System.out.println(htmlForDoc(kb,term,"EnglishLanguage",arg2,false,false));
+            if (debug) System.out.println(htmlForDoc(kb,term,"EnglishLanguage",arg2,false,false));
             shade = !shade;
         }
-        System.out.println("</table>\n");
+        if (debug) System.out.println("</table>\n");
     }
 
     /** *************************************************************
@@ -1594,8 +1593,8 @@ public class KButilities implements ServletContextListener {
         List<String> lines = FileUtil.readLines(file);
         List<String> aux = new ArrayList<>();
         genDocHeader(true); // true = one page
-        System.out.println("<h2>Data Dictionary</h2>");
-        System.out.println("<table><tr><th style:\"width:20%\"><b>Term</b></th><th><b>label</b></th><th><b>in List or Aux</b></th><th style=\"width:75%\"><b>Doc</b></th></tr>\n");
+        if (debug) System.out.println("<h2>Data Dictionary</h2>");
+        if (debug) System.out.println("<table><tr><th style:\"width:20%\"><b>Term</b></th><th><b>label</b></th><th><b>in List or Aux</b></th><th style=\"width:75%\"><b>Doc</b></th></tr>\n");
         Map<String,String> map = genDocList(kb);
         boolean shade = false;
         List<String> links;
@@ -1607,13 +1606,13 @@ public class KButilities implements ServletContextListener {
             aux.addAll(links);
             arg2 = map.get(term);
             if (shade)
-                System.out.println("<tr bgcolor=\"#ddd\"><td>");
+                if (debug) System.out.println("<tr bgcolor=\"#ddd\"><td>");
             else
-                System.out.println("<tr><td>");
-            System.out.println(htmlForDoc(kb,term,"EnglishLanguage",arg2,false,true));
+                if (debug) System.out.println("<tr><td>");
+            if (debug) System.out.println(htmlForDoc(kb,term,"EnglishLanguage",arg2,false,true));
             shade = !shade;
         }
-        System.out.println("</table>\n");
+        if (debug) System.out.println("</table>\n");
     }
 
     /** ***************************************************************
@@ -1646,24 +1645,24 @@ public class KButilities implements ServletContextListener {
     public static void shutDownExecutorService() {
         synchronized (executorLock) {
             if (currentExecutorService != null) {
-                System.out.println("KButilities.shutDownExecutorService(): Initiating executor shutdown");
+                if (debug) System.out.println("KButilities.shutDownExecutorService(): Initiating executor shutdown");
                 currentExecutorService.shutdown();
                 try {
                     // Give translation processes more time to complete
                     int timeoutSeconds = isJEditMode ? 10 : 60;
                     if (!currentExecutorService.awaitTermination(timeoutSeconds, TimeUnit.SECONDS)) {
-                        System.out.println("KButilities.shutDownExecutorService(): Forcing immediate shutdown");
+                        if (debug) System.out.println("KButilities.shutDownExecutorService(): Forcing immediate shutdown");
                         List<Runnable> unfinishedTasks = currentExecutorService.shutdownNow();
-                        System.out.println("KButilities.shutDownExecutorService(): " + unfinishedTasks.size() + " tasks were cancelled");
+                        if (debug) System.out.println("KButilities.shutDownExecutorService(): " + unfinishedTasks.size() + " tasks were cancelled");
 
                         // Give forceful shutdown a moment to complete
                         if (!currentExecutorService.awaitTermination(10, TimeUnit.SECONDS)) {
-                            System.err.println("KButilities.shutDownExecutorService(): ExecutorService did not terminate cleanly");
+                            if (debug) System.err.println("KButilities.shutDownExecutorService(): ExecutorService did not terminate cleanly");
                         }
                     }
-                    System.out.println("KButilities.shutDownExecutorService(): ExecutorService shutdown complete");
+                    if (debug) System.out.println("KButilities.shutDownExecutorService(): ExecutorService shutdown complete");
                 } catch (InterruptedException e) {
-                    System.err.println("KButilities.shutDownExecutorService(): Shutdown interrupted, forcing immediate termination");
+                    if (debug) System.err.println("KButilities.shutDownExecutorService(): Shutdown interrupted, forcing immediate termination");
                     currentExecutorService.shutdownNow();
                     Thread.currentThread().interrupt();
                 }
@@ -1769,7 +1768,7 @@ public class KButilities implements ServletContextListener {
                 if (valid)
                     System.out.println(sb.append(valid));
                 else
-                    System.err.println(sb.append(valid));
+                    if (debug) System.err.println(sb.append(valid));
             }
             else if (args != null && args.length > 1 && args[0].equals("-a")) {
                 SUMOtoTFAform.initOnce();

--- a/web/jsp/BrowseHeader.jsp
+++ b/web/jsp/BrowseHeader.jsp
@@ -16,7 +16,7 @@
 
   String word = ValidationUtils.sanitizeSumoTerm(request.getParameter("word"));
 
-  String POS = ValidationUtils.santizeString(request.getParameter("POS"), "0");
+  String POS = ValidationUtils.sanitizeString(request.getParameter("POS"), "0");
   if (POS == null)
       POS = "0";
 %>

--- a/web/jsp/BrowseHeader.jsp
+++ b/web/jsp/BrowseHeader.jsp
@@ -16,7 +16,7 @@
 
   String word = ValidationUtils.sanitizeSumoTerm(request.getParameter("word"));
 
-  String POS = StringUtil.removeHTML(request.getParameter("POS"));
+  String POS = ValidationUtils.santizeString(request.getParameter("POS"), "0");
   if (POS == null)
       POS = "0";
 %>

--- a/web/jsp/Diag.jsp
+++ b/web/jsp/Diag.jsp
@@ -145,7 +145,7 @@
   // Files with mutual term dependencies
   out.println("<details>");
   out.println("<summary><b>Warning: Files with mutual dependencies</b><hr></summary>");
-  out.println(Diagnostics.printTermDependency(kb,kbHref));
+  out.println(Diagnostics.printMutualDependencies(kb,kbHref));
   out.println("</details></br>");
 
   // Diagnostic runtime

--- a/web/jsp/Diag.jsp
+++ b/web/jsp/Diag.jsp
@@ -19,11 +19,10 @@
     http://github.com/ontologyportal
 */
 
-if (!role.equals("admin") && !role.equals("user")) {
+  if (!role.equals("admin") && !role.equals("user")) {
     response.sendRedirect("KBs.jsp");
     return;
-}
-
+  }
   System.out.println("INFO in Diag.jsp: Running diagnostics");
   long t0 = System.currentTimeMillis();
   String kbHref = null;
@@ -38,29 +37,37 @@ if (!role.equals("admin") && !role.equals("user")) {
     %>
     <%@include file="CommonHeader.jsp" %>
 </form>
-
+<table ALIGN="LEFT" WIDTH=80%><tr><TD BGCOLOR='#AAAAAA'>
+<IMG SRC='pixmaps/1pixel.gif' width=1 height=1 border=0></TD></tr></table><BR>
 <a href="WNDiag.jsp?kb=<%=kbName%>">Run WordNet diagnostics</a><p>
-
 <%
   // Terms without parents
   List<String> termsWithoutParent = Diagnostics.termsNotBelowEntity(kb);
-  out.println(HTMLformatter.htmlDivider("Error: Terms without a root at Entity"));
+  out.println("<details>");
+  out.println("<summary><b>Error: Terms without a root at Entity</b><hr></summary>");
   out.println(HTMLformatter.termList(termsWithoutParent,kbHref));
+  out.println("</details></br>");
 
   // Children of disjoint parents
   List<String> disjoint = Diagnostics.childrenOfDisjointParents(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Error: Terms with disjoint parents"));
+  out.println("<details>");
+  out.println("<summary><b>Error: Terms with disjoint parents</b><hr></summary>");
   out.println(HTMLformatter.termList(disjoint,kbHref));
+  out.println("</details></br>");
 
   // Children of disjoint parents
   List<String> parts = Diagnostics.partitionViolation(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Error: Partition violations"));
+  out.println("<details>");
+  out.println("<summary><b>Error: Partition violations</b><hr></summary>");
   for (String s : parts) {
       out.println(s + "<br>\n");
   }
   out.println(HTMLformatter.termList(disjoint,kbHref));
+  out.println("</details></br>");
 
-  out.println("<br>" + HTMLformatter.htmlDivider("Error: Formulae with type conflicts"));
+  // Formulae with type conflicts
+  out.println("<details>");
+  out.println("<summary><b>Error: Formulae with type conflicts</b><hr></summary>");
   KButilities.clearErrors();
   kb.kbCache.errors.clear();
   SUMOtoTFAform.errors.clear();
@@ -73,51 +80,75 @@ if (!role.equals("admin") && !role.equals("user")) {
       kb.kbCache.errors.clear();
       SUMOtoTFAform.errors.clear();
   }
+  out.println("</details></br>");
 
   // relations without format
   List<String> termsWithoutFormat = Diagnostics.relationsWithoutFormat(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Relations without format"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Relations without format</b><hr></summary>");
   out.println(HTMLformatter.termList(termsWithoutFormat,kbHref));
+  out.println("</details></br>");
 
   // Terms without documentation
   List<String> termsWithoutDoc = Diagnostics.termsWithoutDoc(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Terms without documentation"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Terms without documentation</b><hr></summary>");
   out.println(HTMLformatter.termList(termsWithoutDoc,kbHref));
+  out.println("</details></br>");
 
   // Terms with multiple documentation
   List<String> termsWithMultipleDoc = Diagnostics.termsWithMultipleDoc(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Terms with multiple documentation"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Terms with multiple documentation</b><hr></summary>");
   out.println(HTMLformatter.termList(termsWithMultipleDoc,kbHref));
+  out.println("</details></br>");
 
   // Terms differing only in capitalization
   List<String> termCapDiff = Diagnostics.termCapDiff(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Terms differing only in capitalization"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Terms differing only in capitalization</b><hr></summary>");
   out.println(HTMLformatter.termList(termCapDiff,kbHref));
+  out.println("</details></br>");
 
   // Members (instances) of a parent class that are not also members
   // of one of the subclasses that constitute the exhaustive
   // decomposition of the parent class.
   List<String> termsMissingFromPartition = Diagnostics.membersNotInAnyPartitionClass(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Instances of a partitioned class that are not instances of one of the class's partitioning subclasses"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Instances of a partitioned class that are not instances of one of the class's partitioning subclasses</b><hr></summary>");
   out.println(HTMLformatter.termList(termsMissingFromPartition,kbHref));
+  out.println("</details></br>");
 
+  // Terms without rules
   List<String> norule = Diagnostics.termsWithoutRules(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Terms that do not appear in any rules"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Terms that do not appear in any rules</b><hr></summary>");
   out.println(HTMLformatter.termList(norule,kbHref));
+  out.println("</details></br>");
 
+  // Formulae extraneous quanitified variables
   List<Formula> noquant = Diagnostics.quantifierNotInBody(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Formulae with extraneous quantified variables"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Formulae with extraneous quantified variables</b><hr></summary>");
   for (Formula f : noquant)
 	  out.println(f.htmlFormat(kbHref) + "<p>");
+  out.println("</details></br>");
 
+  // Formulae with unquantified variables appearing only in consequent
   List<Formula> noquantconseq = Diagnostics.unquantsInConseq(kb);
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Formulae with unquantified variable appearing only in consequent"));
+  out.println("<details>");
+  out.println("<summary><b>Warning: Formulae with unquantified variable appearing only in consequent</b><hr></summary>");
   for (Formula f : noquantconseq)
 	  out.println(f.htmlFormat(kbHref) + "<p>");
+  out.println("</details></br>");
 
-  out.println("<br>" + HTMLformatter.htmlDivider("Warning: Files with mutual dependencies"));
+  // Files with mutual term dependencies
+  out.println("<details>");
+  out.println("<summary><b>Warning: Files with mutual dependencies</b><hr></summary>");
   out.println(Diagnostics.printTermDependency(kb,kbHref));
+  out.println("</details></br>");
 
+  // Diagnostic runtime
   System.out.println("  > " + ((System.currentTimeMillis() - t0) / 1000.0)
                      + " seconds to run all diagnostics");
 %>


### PR DESCRIPTION
Added Diagnostics.mutualDependency() which finds mutual term dependencies between kif files. 

Then added Diagnostics.printMutualDependencies() which calls mutualDependency() and returns HTML output of the mutual dependent files and the terms the less dependent file takes from the more dependent file.

printMutualDependencies() is then called in Diag.jsp to show the user a list of mutual dependencies with the goal of reducing them.