### PR TITLE
Fixed Failing Tests Caused by Changing Formula Max Arity

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -97,7 +97,7 @@ jobs:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
           SIGMA_SRC: ${{ github.workspace }}/sigmakee
           ONTOLOGYPORTAL_GIT: ${{ github.workspace }}
-          SIGMA_SKIP_TPTP_BG: "true"
+          TPTP_BG_WAIT: "true"
         working-directory: ./sigmakee
         run: |
           ant test.unit
@@ -121,7 +121,7 @@ jobs:
       - name: Setup KB for integration tests
         env:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
-          SIGMA_SKIP_TPTP_BG: "true"
+          TPTP_BG_WAIT: "true"
         working-directory: ${{ github.workspace }}
         run: >
           sed -i '/<\/configuration>/i\
@@ -137,7 +137,7 @@ jobs:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
           SIGMA_SRC: ${{ github.workspace }}/sigmakee
           ONTOLOGYPORTAL_GIT: ${{ github.workspace }}
-          SIGMA_TPTP_BG: "true"
+          TPTP_BG_WAIT: "true"
         working-directory: ./sigmakee
         run: |
           ant test.integration

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -137,7 +137,7 @@ jobs:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
           SIGMA_SRC: ${{ github.workspace }}/sigmakee
           ONTOLOGYPORTAL_GIT: ${{ github.workspace }}
-          SIGMA_SKIP_TPTP_BG: "true"
+          SIGMA_TPTP_BG: "true"
         working-directory: ./sigmakee
         run: |
           ant test.integration

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -97,6 +97,7 @@ jobs:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
           SIGMA_SRC: ${{ github.workspace }}/sigmakee
           ONTOLOGYPORTAL_GIT: ${{ github.workspace }}
+          SIGMA_SKIP_TPTP_BG: "true"
         working-directory: ./sigmakee
         run: |
           ant test.unit
@@ -120,6 +121,7 @@ jobs:
       - name: Setup KB for integration tests
         env:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
+          SIGMA_SKIP_TPTP_BG: "true"
         working-directory: ${{ github.workspace }}
         run: >
           sed -i '/<\/configuration>/i\
@@ -135,6 +137,7 @@ jobs:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
           SIGMA_SRC: ${{ github.workspace }}/sigmakee
           ONTOLOGYPORTAL_GIT: ${{ github.workspace }}
+          SIGMA_SKIP_TPTP_BG: "true"
         working-directory: ./sigmakee
         run: |
           ant test.integration

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -107,6 +107,7 @@ jobs:
           SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
           SIGMA_SRC: ${{ github.workspace }}/sigmakee
           ONTOLOGYPORTAL_GIT: ${{ github.workspace }}
+          TPTP_BG_WAIT: "true"
         working-directory: ${{ github.workspace }}
         run: |
           find $SIGMA_HOME/KBs -name '**/*.ser' -delete

--- a/src/java/com/articulate/sigma/Formula.java
+++ b/src/java/com/articulate/sigma/Formula.java
@@ -250,7 +250,7 @@ public class Formula implements Comparable, Serializable {
      * This constant indicates the maximum predicate arity supported
      * by the current implementation of Sigma.
      */
-    public static final int MAX_PREDICATE_ARITY = 7;
+    public static final int MAX_PREDICATE_ARITY = 10;
 
     /*******************************************************************
      * Getter for the source file of this Formula

--- a/src/java/com/articulate/sigma/KBcache.java
+++ b/src/java/com/articulate/sigma/KBcache.java
@@ -2304,7 +2304,8 @@ public class KBcache implements Serializable {
     public void buildCaches() {
 
         clearCaches(); // ensure a clean slate
-        p_buildCaches();
+        buildCaches_singleThread();
+        // p_buildCaches();
     }
 
     /** ***************************************************************
@@ -2386,6 +2387,49 @@ public class KBcache implements Serializable {
         System.out.printf("INFO in KBcache.buildCaches(): size: %d%n", instanceOf.keySet().size());
         System.out.printf("KBcache.buildCaches():                              %d total seconds%n", (System.currentTimeMillis() - startMillis) / KButilities.ONE_K);
         initialized = true;
+    }
+
+    private void buildCaches_singleThread() {
+
+        long startMillis = System.currentTimeMillis();
+        // Pre-warm Formula.stringArgs single-threaded.
+        for (Formula f : kb.formulaMap.values())
+            f.getStringArgument(0);
+        // Former Wave 1
+        buildInsts();
+        LoggingUtils.printProgressBar("INFO", "buildInsts:", 1, 10);
+        buildRelationsSet();
+        buildTransitiveRelationsSet();
+        buildDirectParentTerms();
+        LoggingUtils.printProgressBar("INFO", "relations/transitive/direct parents:", 2, 10);
+        // Former Wave 2
+        buildParents();
+        buildChildren();
+        LoggingUtils.printProgressBar("INFO", "buildParents+buildChildren:", 3, 10);
+        // Former Wave 3
+        collectDomains();
+        buildDirectInstances();
+        LoggingUtils.printProgressBar("INFO", "collectDomains+buildDirectInstances:", 4, 10);
+        // Former Wave 4
+        buildInstTransRels();
+        LoggingUtils.printProgressBar("INFO", "buildInstTransRels:", 5, 10);
+        addTransitiveInstances();
+        LoggingUtils.printProgressBar("INFO", "addTransitiveInstances:", 6, 10);
+        buildTransInstOf();
+        correctValences();
+        buildFunctionsSet();
+        LoggingUtils.printProgressBar("INFO", "transInstOf+valences+functions:", 7, 10);
+        if (KBmanager.getMgr().getPref("cacheDisjoint").equals("true")) {
+            buildExplicitDisjointMap();
+            buildDisjointRelationsMap();
+            buildDisjointMap();
+        }
+        storeCacheAsFormulas();
+        LoggingUtils.printProgressBar("INFO", "storeCacheAsFormulas:", 8, 10);
+        buildSymbolTaxonomy();
+        LoggingUtils.printProgressBar("INFO", "buildSymbolTaxonomy:", 9, 10);
+        initialized = true;
+        LoggingUtils.printProgressBar("INFO", "Completed cache:", 10, 10, (System.currentTimeMillis() - startMillis) + " milliseconds");
     }
 
     /** ***************************************************************

--- a/src/java/com/articulate/sigma/KBmanager.java
+++ b/src/java/com/articulate/sigma/KBmanager.java
@@ -851,9 +851,14 @@ public class KBmanager implements Serializable {
             }
             initializing = false;
             initialized = true;
-            if (!"true".equalsIgnoreCase(System.getenv("SIGMA_SKIP_TPTP_BG"))) {
-                LoggingUtils.log("Starting TPTP Background Generation...");
-                TPTPGenerationManager.startBackgroundGeneration();
+            LoggingUtils.log("Starting TPTP Background Generation...");
+            TPTPGenerationManager.startBackgroundGeneration();
+            if ("true".equalsIgnoreCase(System.getenv("TPTP_BG_WAIT"))) {
+                try {
+                    Thread.sleep(120000); 
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
             }
         }
         catch (Exception ex) {

--- a/src/java/com/articulate/sigma/KBmanager.java
+++ b/src/java/com/articulate/sigma/KBmanager.java
@@ -851,8 +851,10 @@ public class KBmanager implements Serializable {
             }
             initializing = false;
             initialized = true;
-            LoggingUtils.log("Starting TPTP Background Generation...");
-            TPTPGenerationManager.startBackgroundGeneration();
+            if (!"true".equalsIgnoreCase(System.getenv("SIGMA_SKIP_TPTP_BG"))) {
+                LoggingUtils.log("Starting TPTP Background Generation...");
+                TPTPGenerationManager.startBackgroundGeneration();
+            }
         }
         catch (Exception ex) {
             initializing = false;

--- a/src/java/com/articulate/sigma/RowVars.java
+++ b/src/java/com/articulate/sigma/RowVars.java
@@ -12,7 +12,7 @@ import java.util.*;
 public class RowVars {
 
     public static boolean DEBUG = false;
-    public static final int MAX_ARITY = 5;
+    public static final int MAX_ARITY = Formula.MAX_PREDICATE_ARITY - 2;
 
     /** ***************************************************************
      * @return a HashSet, possibly empty, containing row variable

--- a/test/unit/java/com/articulate/sigma/FormulaPreprocessorTest.java
+++ b/test/unit/java/com/articulate/sigma/FormulaPreprocessorTest.java
@@ -46,7 +46,7 @@ public class FormulaPreprocessorTest extends UnitTestBase  {
 
         Map<String, List> actualMap = f.gatherRelationsWithArgTypes(SigmaTestBase.kb);
 
-        List<String> expectedList = Lists.newArrayList(null, "Process", "AutonomousAgent", null, null, null, null, null);
+        List<String> expectedList = Lists.newArrayList(null, "Process", "AutonomousAgent", null, null, null, null, null, null, null, null);
         Map<String, List> expectedMap = Maps.newHashMap();
         expectedMap.put("agent", expectedList);
 


### PR DESCRIPTION
Was getting a concurrent modification exception due to TPTPGenerationManager modifying the cache as KBcache was accessing a hash map. Fixed by adding a delay to TPTP Generation if an environment variable TPTP_BG_WAIT=='true'. This is a messy fix, ideally the KBmanager should wait for TPTP generation to complete before becoming available for usages that require TPTP.