### PR TITLE
Updated TheoremProverController CLI

### DIFF
--- a/src/java/com/articulate/sigma/InferenceTestSuite.java
+++ b/src/java/com/articulate/sigma/InferenceTestSuite.java
@@ -45,6 +45,7 @@ import com.articulate.sigma.tp.Vampire;
 import com.articulate.sigma.trans.*;
 import com.articulate.sigma.utils.FileUtil;
 import com.articulate.sigma.utils.StringUtil;
+import com.articulate.sigma.utils.LoggingUtils;
 import com.articulate.sigma.parsing.CLIMapParser;
 
 import java.io.File;
@@ -58,22 +59,29 @@ import java.util.*;
 
 public class InferenceTestSuite {
 
-    /** Total time */
-    public static long totalTime = 0;
-
-    /** Default timeout for queries with unspecified timeouts or override when selected */
-    public static int _DEFAULT_TIMEOUT = 30;
-
-    public static boolean overrideTimeout = false;
-
-    public KB kb = null;
-
     public static boolean debug = false;
 
-    // save TPTP translations of each problem as <probName>.p
+    private KB kb = null;
+
+    private String inferenceTestDir;
+
+    private List<String> inferenceTestPaths = new ArrayList<>(); 
+
+    /** Default timeout for queries with unspecified timeouts or override when selected */
+    public static int DEFAULT_TIMEOUT = 30;
+
+    public static boolean OVERRIDE_TIMEOUT = false;
+
+    /** Save TPTP translations of each problem as <probName>.p */
     public static boolean saveTPTP =  true;
 
     public static Set<String> metaPred = new HashSet(Arrays.asList("note", "time", "query", "answer"));
+
+    public InferenceTestSuite(KB kb) {
+        this.kb = kb;
+        this.inferenceTestDir = KBmanager.getMgr().getPref("inferenceTestDir");
+        this.inferenceTestPaths = loadInferenceTestPaths();
+    }
 
     public static class OneResult {
         public boolean pass;
@@ -83,6 +91,24 @@ public class InferenceTestSuite {
         public java.util.List<String> actual;
         public List<String> proofText;
     }
+
+    private List<String> getInferenceTestPaths() {
+
+        return this.inferenceTestPaths;
+    }
+
+    
+    private List<String> loadInferenceTestPaths() {
+        
+        File dir = new File(this.inferenceTestDir);
+        File[] files = dir.listFiles((d, n) -> n.toLowerCase().endsWith(".tq"));
+        Arrays.sort(files, Comparator.comparing(File::getName, String.CASE_INSENSITIVE_ORDER));
+        List<String> inferenceTestPaths = new ArrayList<>();
+        for (int i = 0; i < files.length; i++) inferenceTestPaths.add(files[i].getName());
+        LoggingUtils.log("Loaded " + inferenceTestPaths.size() + " .tq inference test files!");
+        return inferenceTestPaths;
+    }
+
 
     /** ***************************************************************
      * Thin wrapper for the JSP buttons: returns PASS/FAIL + time +
@@ -159,11 +185,11 @@ public class InferenceTestSuite {
         final File tf = new File(tqPath);
         InfTestData itd = readTestFile(tf);
 
-        // Apply timeout policy (mirror test(); if overrideTimeout is true, force default)
-        if (overrideTimeout) {
-            itd.timeout = timeoutSec > 0 ? timeoutSec : _DEFAULT_TIMEOUT;   // was _DEFAULT_TIMEOUT only
+        // Apply timeout policy (mirror test(); if OVERRIDE_TIMEOUT is true, force default)
+        if (OVERRIDE_TIMEOUT) {
+            itd.timeout = timeoutSec > 0 ? timeoutSec : DEFAULT_TIMEOUT;   // was DEFAULT_TIMEOUT only
         } else {
-            itd.timeout = timeoutSec > 0 ? timeoutSec : (itd.timeout > 0 ? itd.timeout : _DEFAULT_TIMEOUT);
+            itd.timeout = timeoutSec > 0 ? timeoutSec : (itd.timeout > 0 ? itd.timeout : DEFAULT_TIMEOUT);
         }
 
         // --- Isolated assertion block (prevents KB pollution) ---
@@ -478,7 +504,7 @@ public class InferenceTestSuite {
      * Convenience method that sets default parameters
     */
     public String test(KB kb) throws IOException  {
-        return test(kb, _DEFAULT_TIMEOUT, "");
+        return test(kb, DEFAULT_TIMEOUT, "");
     }
 
     /** ***************************************************************
@@ -717,7 +743,7 @@ public class InferenceTestSuite {
 
         String language = "EnglishLanguage";
         int maxAnswers;
-        totalTime = 0;
+        double totalTime = 0;
         long duration = 0;
         result = result.append("<h2>Inference tests</h2>\n");
         result = result.append("<table><tr><td>name</td><td>test file</td><td>result</td><td>Time (ms)</td></tr>");
@@ -727,9 +753,8 @@ public class InferenceTestSuite {
         List<File> files = new ArrayList();
         String error = getTestFiles(files,outputDir);
         copyTestFiles(files,outputDir);
-        if (error != null)
-            return error;
-
+        if (error != null) return error;
+        
         List<InfTestData> tests = readTestFiles(files);
         System.out.println("INFO in InferenceTestSuite.test(): number of files: " + files.size());
         int counter = 0;
@@ -768,7 +793,7 @@ public class InferenceTestSuite {
                     start = System.currentTimeMillis();
                     System.out.println("INFO in InferenceTestSuite.test(): Query " + processed + " is posed to " + KBmanager.getMgr().prover);
                     int actualTimeout = itd.timeout;
-                    if (overrideTimeout)
+                    if (OVERRIDE_TIMEOUT)
                         actualTimeout = defaultTimeout;
                     if (KBmanager.getMgr().prover == KBmanager.Prover.EPROVER) {
                         com.articulate.sigma.tp.EProver eprover = new  com.articulate.sigma.tp.EProver(kb, "tptp", actualTimeout, maxAnswers);
@@ -871,8 +896,8 @@ public class InferenceTestSuite {
         System.out.println("INFO in InferenceTestSuite.inferenceUnitTest(): testpath: " + testpath);
         // read the test file
         InfTestData itd = readTestFile(new File(testpath));
-        if (overrideTimeout)
-            itd.timeout = _DEFAULT_TIMEOUT;
+        if (OVERRIDE_TIMEOUT)
+            itd.timeout = DEFAULT_TIMEOUT;
         compareFiles(itd);
         for (String formula : itd.statements)
              kb.tell(formula);
@@ -1114,6 +1139,7 @@ public class InferenceTestSuite {
         System.out.println("or (file \"path\")");
         System.out.println("  options:");
         System.out.println("  -h - show this help screen");
+        System.out.println("  -p - print available inference test paths");
         System.out.println("  --test <name> - run named test file in config.xml inferenceTestDir");
         System.out.println("  --inf <mode> - run test files known to pass in the given mode in config.xml inferenceTestDir");
         System.out.println("  --all <mode> - run all test files in the given mode in config.xml inferenceTestDir");
@@ -1122,7 +1148,7 @@ public class InferenceTestSuite {
         System.out.println("     l - run with LEO-III (add letter to options above)");
         System.out.println("     f - run with TF0 language");
         System.out.println("     0 - run with TH0 language");
-        System.out.println("     o - override test timeout with global timeout of " + _DEFAULT_TIMEOUT + " sec");
+        System.out.println("     o - override test timeout with global timeout of " + DEFAULT_TIMEOUT + " sec");
     }
 
      /** ***************************************************************
@@ -1132,21 +1158,21 @@ public class InferenceTestSuite {
 
         System.out.println("INFO in KB.main()");
         Map<String, List<String>> argMap = CLIMapParser.parse(args);
-        if (argMap.isEmpty() || argMap.containsKey("h"))
-            showHelp();
+        if (argMap.isEmpty() || argMap.containsKey("h")) showHelp();
         else {
             KBmanager.getMgr().initializeOnce();
-            InferenceTestSuite its = new InferenceTestSuite();
-            if (argMap.containsKey("l"))
-                SUMOKBtoTPTPKB.setLang("thf");
-            if (argMap.containsKey("f"))
-                SUMOKBtoTPTPKB.setLang("tff");
+            InferenceTestSuite inferenceTestSuite = new InferenceTestSuite(KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname")));
+            if (argMap.containsKey("l")) SUMOKBtoTPTPKB.setLang("thf");
+            if (argMap.containsKey("f")) SUMOKBtoTPTPKB.setLang("tff");
             KB kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname"));
             try {
                 resetAllForInference(kb);
             }
             catch (IOException e) {
                 e.printStackTrace();
+            }
+            if (argMap.containsKey("p")) {
+                for (String path : inferenceTestSuite.getInferenceTestPaths()) LoggingUtils.log("  " + path);
             }
             if (argMap.containsKey("e")) {
                 KBmanager.getMgr().prover = KBmanager.Prover.EPROVER;
@@ -1167,25 +1193,24 @@ public class InferenceTestSuite {
             if (argMap.containsKey("v"))
                 KBmanager.getMgr().prover = KBmanager.Prover.VAMPIRE;
             if (argMap.containsKey("o"))
-                overrideTimeout = true;
+                OVERRIDE_TIMEOUT = true;
             System.out.println("in InferenceTestSuite.main(): using prover: " + KBmanager.getMgr().prover);
 
             if (argMap.containsKey("test")) {
-                its.cmdLineTest(argMap.get("test").get(0));
+                inferenceTestSuite.cmdLineTest(argMap.get("test").get(0));
             }
             else if (argMap.containsKey("inf")) {
-                its.runPassing();
+                inferenceTestSuite.runPassing();
             }
             else if (argMap.containsKey("all")) {
                 try {
-                    its.test(kb);
+                    inferenceTestSuite.test(kb);
                 }
                 catch (IOException e) {
                     e.printStackTrace();
                 }
             }
-            else
-                showHelp();
+            else showHelp();
         }
     }
 }

--- a/src/java/com/articulate/sigma/InferenceTestSuite.java
+++ b/src/java/com/articulate/sigma/InferenceTestSuite.java
@@ -45,7 +45,6 @@ import com.articulate.sigma.tp.Vampire;
 import com.articulate.sigma.trans.*;
 import com.articulate.sigma.utils.FileUtil;
 import com.articulate.sigma.utils.StringUtil;
-import com.articulate.sigma.utils.LoggingUtils;
 import com.articulate.sigma.parsing.CLIMapParser;
 
 import java.io.File;
@@ -59,29 +58,22 @@ import java.util.*;
 
 public class InferenceTestSuite {
 
-    public static boolean debug = false;
-
-    private KB kb = null;
-
-    private String inferenceTestDir;
-
-    private List<String> inferenceTestPaths = new ArrayList<>(); 
+    /** Total time */
+    public static long totalTime = 0;
 
     /** Default timeout for queries with unspecified timeouts or override when selected */
-    public static int DEFAULT_TIMEOUT = 30;
+    public static int _DEFAULT_TIMEOUT = 30;
 
-    public static boolean OVERRIDE_TIMEOUT = false;
+    public static boolean overrideTimeout = false;
 
-    /** Save TPTP translations of each problem as <probName>.p */
+    public KB kb = null;
+
+    public static boolean debug = false;
+
+    // save TPTP translations of each problem as <probName>.p
     public static boolean saveTPTP =  true;
 
     public static Set<String> metaPred = new HashSet(Arrays.asList("note", "time", "query", "answer"));
-
-    public InferenceTestSuite(KB kb) {
-        this.kb = kb;
-        this.inferenceTestDir = KBmanager.getMgr().getPref("inferenceTestDir");
-        this.inferenceTestPaths = loadInferenceTestPaths();
-    }
 
     public static class OneResult {
         public boolean pass;
@@ -92,23 +84,13 @@ public class InferenceTestSuite {
         public List<String> proofText;
     }
 
-    private List<String> getInferenceTestPaths() {
+    public InferenceTestSuite(KB kb) {
 
-        return this.inferenceTestPaths;
-    }
-
+    }    
     
-    private List<String> loadInferenceTestPaths() {
-        
-        File dir = new File(this.inferenceTestDir);
-        File[] files = dir.listFiles((d, n) -> n.toLowerCase().endsWith(".tq"));
-        Arrays.sort(files, Comparator.comparing(File::getName, String.CASE_INSENSITIVE_ORDER));
-        List<String> inferenceTestPaths = new ArrayList<>();
-        for (int i = 0; i < files.length; i++) inferenceTestPaths.add(files[i].getName());
-        LoggingUtils.log("Loaded " + inferenceTestPaths.size() + " .tq inference test files!");
-        return inferenceTestPaths;
-    }
+    public InferenceTestSuite() {
 
+    }
 
     /** ***************************************************************
      * Thin wrapper for the JSP buttons: returns PASS/FAIL + time +
@@ -185,11 +167,11 @@ public class InferenceTestSuite {
         final File tf = new File(tqPath);
         InfTestData itd = readTestFile(tf);
 
-        // Apply timeout policy (mirror test(); if OVERRIDE_TIMEOUT is true, force default)
-        if (OVERRIDE_TIMEOUT) {
-            itd.timeout = timeoutSec > 0 ? timeoutSec : DEFAULT_TIMEOUT;   // was DEFAULT_TIMEOUT only
+        // Apply timeout policy (mirror test(); if overrideTimeout is true, force default)
+        if (overrideTimeout) {
+            itd.timeout = timeoutSec > 0 ? timeoutSec : _DEFAULT_TIMEOUT;   // was _DEFAULT_TIMEOUT only
         } else {
-            itd.timeout = timeoutSec > 0 ? timeoutSec : (itd.timeout > 0 ? itd.timeout : DEFAULT_TIMEOUT);
+            itd.timeout = timeoutSec > 0 ? timeoutSec : (itd.timeout > 0 ? itd.timeout : _DEFAULT_TIMEOUT);
         }
 
         // --- Isolated assertion block (prevents KB pollution) ---
@@ -504,7 +486,7 @@ public class InferenceTestSuite {
      * Convenience method that sets default parameters
     */
     public String test(KB kb) throws IOException  {
-        return test(kb, DEFAULT_TIMEOUT, "");
+        return test(kb, _DEFAULT_TIMEOUT, "");
     }
 
     /** ***************************************************************
@@ -743,7 +725,7 @@ public class InferenceTestSuite {
 
         String language = "EnglishLanguage";
         int maxAnswers;
-        double totalTime = 0;
+        totalTime = 0;
         long duration = 0;
         result = result.append("<h2>Inference tests</h2>\n");
         result = result.append("<table><tr><td>name</td><td>test file</td><td>result</td><td>Time (ms)</td></tr>");
@@ -753,8 +735,9 @@ public class InferenceTestSuite {
         List<File> files = new ArrayList();
         String error = getTestFiles(files,outputDir);
         copyTestFiles(files,outputDir);
-        if (error != null) return error;
-        
+        if (error != null)
+            return error;
+
         List<InfTestData> tests = readTestFiles(files);
         System.out.println("INFO in InferenceTestSuite.test(): number of files: " + files.size());
         int counter = 0;
@@ -793,7 +776,7 @@ public class InferenceTestSuite {
                     start = System.currentTimeMillis();
                     System.out.println("INFO in InferenceTestSuite.test(): Query " + processed + " is posed to " + KBmanager.getMgr().prover);
                     int actualTimeout = itd.timeout;
-                    if (OVERRIDE_TIMEOUT)
+                    if (overrideTimeout)
                         actualTimeout = defaultTimeout;
                     if (KBmanager.getMgr().prover == KBmanager.Prover.EPROVER) {
                         com.articulate.sigma.tp.EProver eprover = new  com.articulate.sigma.tp.EProver(kb, "tptp", actualTimeout, maxAnswers);
@@ -896,8 +879,8 @@ public class InferenceTestSuite {
         System.out.println("INFO in InferenceTestSuite.inferenceUnitTest(): testpath: " + testpath);
         // read the test file
         InfTestData itd = readTestFile(new File(testpath));
-        if (OVERRIDE_TIMEOUT)
-            itd.timeout = DEFAULT_TIMEOUT;
+        if (overrideTimeout)
+            itd.timeout = _DEFAULT_TIMEOUT;
         compareFiles(itd);
         for (String formula : itd.statements)
              kb.tell(formula);
@@ -1139,7 +1122,6 @@ public class InferenceTestSuite {
         System.out.println("or (file \"path\")");
         System.out.println("  options:");
         System.out.println("  -h - show this help screen");
-        System.out.println("  -p - print available inference test paths");
         System.out.println("  --test <name> - run named test file in config.xml inferenceTestDir");
         System.out.println("  --inf <mode> - run test files known to pass in the given mode in config.xml inferenceTestDir");
         System.out.println("  --all <mode> - run all test files in the given mode in config.xml inferenceTestDir");
@@ -1148,7 +1130,7 @@ public class InferenceTestSuite {
         System.out.println("     l - run with LEO-III (add letter to options above)");
         System.out.println("     f - run with TF0 language");
         System.out.println("     0 - run with TH0 language");
-        System.out.println("     o - override test timeout with global timeout of " + DEFAULT_TIMEOUT + " sec");
+        System.out.println("     o - override test timeout with global timeout of " + _DEFAULT_TIMEOUT + " sec");
     }
 
      /** ***************************************************************
@@ -1158,21 +1140,21 @@ public class InferenceTestSuite {
 
         System.out.println("INFO in KB.main()");
         Map<String, List<String>> argMap = CLIMapParser.parse(args);
-        if (argMap.isEmpty() || argMap.containsKey("h")) showHelp();
+        if (argMap.isEmpty() || argMap.containsKey("h"))
+            showHelp();
         else {
             KBmanager.getMgr().initializeOnce();
-            InferenceTestSuite inferenceTestSuite = new InferenceTestSuite(KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname")));
-            if (argMap.containsKey("l")) SUMOKBtoTPTPKB.setLang("thf");
-            if (argMap.containsKey("f")) SUMOKBtoTPTPKB.setLang("tff");
+            InferenceTestSuite its = new InferenceTestSuite();
+            if (argMap.containsKey("l"))
+                SUMOKBtoTPTPKB.setLang("thf");
+            if (argMap.containsKey("f"))
+                SUMOKBtoTPTPKB.setLang("tff");
             KB kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname"));
             try {
                 resetAllForInference(kb);
             }
             catch (IOException e) {
                 e.printStackTrace();
-            }
-            if (argMap.containsKey("p")) {
-                for (String path : inferenceTestSuite.getInferenceTestPaths()) LoggingUtils.log("  " + path);
             }
             if (argMap.containsKey("e")) {
                 KBmanager.getMgr().prover = KBmanager.Prover.EPROVER;
@@ -1193,26 +1175,26 @@ public class InferenceTestSuite {
             if (argMap.containsKey("v"))
                 KBmanager.getMgr().prover = KBmanager.Prover.VAMPIRE;
             if (argMap.containsKey("o"))
-                OVERRIDE_TIMEOUT = true;
+                overrideTimeout = true;
             System.out.println("in InferenceTestSuite.main(): using prover: " + KBmanager.getMgr().prover);
 
             if (argMap.containsKey("test")) {
-                inferenceTestSuite.cmdLineTest(argMap.get("test").get(0));
+                its.cmdLineTest(argMap.get("test").get(0));
             }
             else if (argMap.containsKey("inf")) {
-                inferenceTestSuite.runPassing();
+                its.runPassing();
             }
             else if (argMap.containsKey("all")) {
                 try {
-                    inferenceTestSuite.test(kb);
+                    its.test(kb);
                 }
                 catch (IOException e) {
                     e.printStackTrace();
                 }
             }
-            else showHelp();
+            else
+                showHelp();
         }
     }
 }
-
 

--- a/src/java/com/articulate/sigma/tp/TheoremProverController.java
+++ b/src/java/com/articulate/sigma/tp/TheoremProverController.java
@@ -118,95 +118,180 @@ public class TheoremProverController {
     }
 
     /********************************************************************
-     * Prints the main() console options for this class
+     * Prints the main() console options for this class.
      */
     private static void showHelp() {
 
-        System.out.println("TheoremProverController class");
-        System.out.println("  h - show this help screen");
-        System.out.println("  -a - print available provers");
-        System.out.println("  -v - query vampire");
-        System.out.println("  -e - query EProver");
-        System.out.println("  -l - query LEO");
+        System.out.println("TheoremProverController");
+        System.out.println("Usage:");
+        System.out.println("  -v \"<SUO-KIF query>\"     Query Vampire");
+        System.out.println("  -e \"<SUO-KIF query>\"     Query EProver");
+        System.out.println("  -l \"<SUO-KIF query>\"     Query LEO");
+        System.out.println("Basic options:");
+        System.out.println("  -h, --help               Show this help screen");
+        System.out.println("  -a, --available          Print available provers");
+        System.out.println("  --timeout <seconds>      Query timeout. Default: 30");
+        System.out.println("  --answers <n>            Max answers. Default: 1");
+        System.out.println("Language options:");
+        System.out.println("  --lang fof               Use FOF/TPTP");
+        System.out.println("  --lang tff               Use TFF");
+        System.out.println("  --lang thf               Use THF/HOL. Vampire and LEO only");
+        System.out.println("Vampire-only options:");
+        System.out.println("  --mode casc              Vampire CASC mode. Default");
+        System.out.println("  --mode avatar            Vampire AVATAR mode");
+        System.out.println("  --mode vampire           Vampire native mode");
+        System.out.println("  --mode custom            Use VAMPIRE_OPTS");
+        System.out.println("  --cwa                    Enable closed world assumption");
+        System.out.println("  --mp                     Enable modus ponens mode");
+        System.out.println("  --dropOnePremise         Drop one-premise formulas. Requires --mp");
+        System.out.println("  --modal                  In THF/HOL mode, use modal THF translation");
+        System.out.println("Examples:");
+        System.out.println("  java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -v \"(subclass ?X Object)\"");
+        System.out.println("  java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -v \"(subclass ?X Object)\" --lang tff");
+        System.out.println("  java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -v \"(instance ?X Relation)\" --lang thf --modal");
+        System.out.println("  java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -v \"(=> (instance ?X Human) (instance ?X Mammal))\" --mp");
+        System.out.println("  java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -e \"(subclass ?X Object)\" --lang fof");
+        System.out.println("  java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -l \"(instance ?X Relation)\"");
     }
     
     /********************************************************************
      * Main method for this class used to test the different theorem provers and their options.
      */
     public static void main(String[] args) {
+
         Map<String, List<String>> argMap = CLIMapParser.parse(args);
-        System.out.printf("TheoremProverController.main(%s)", argMap);
-        TheoremProverController theoremProverController = new TheoremProverController();
-        if (argMap.isEmpty() || argMap.containsKey("h")) {
+        System.out.printf("TheoremProverController.main(%s)%n", argMap);
+        if (argMap.isEmpty() || argMap.containsKey("h") || argMap.containsKey("help")) {
             showHelp();
             return;
         }
         KBmanager.getMgr().initializeOnce();
         KB kb = KBmanager.getMgr().getKB(KBmanager.getMgr().getPref("sumokbname"));
-        if (argMap.containsKey("a")) {
+        if (argMap.containsKey("a") || argMap.containsKey("available")) {
             System.out.println("Available Provers: " + TheoremProverController.availableProvers());
             return;
         }
+        String proverType = null;
+        String queryString = null;
+        if (argMap.containsKey("v")) {
+            proverType = "VAMPIRE";
+            queryString = String.join(" ", argMap.get("v"));
+        }
+        else if (argMap.containsKey("e")) {
+            proverType = "EPROVER";
+            queryString = String.join(" ", argMap.get("e"));
+        }
+        else if (argMap.containsKey("l")) {
+            proverType = "LEO";
+            queryString = String.join(" ", argMap.get("l"));
+        }
+        else {
+            System.err.println("No prover selected. Use -v, -e, or -l.");
+            showHelp();
+            return;
+        }
+        if (queryString == null || queryString.trim().isEmpty()) {
+            System.err.println("Missing SUO-KIF query.");
+            showHelp();
+            return;
+        }
+        String lang = "FOF";
+        if (argMap.containsKey("lang") && !argMap.get("lang").isEmpty()) {
+            lang = argMap.get("lang").get(0).toUpperCase();
+            if ("TPTP".equals(lang)) lang = "FOF";
+        }
+        String vampireMode = "CASC";
+        if (argMap.containsKey("mode") && !argMap.get("mode").isEmpty()) vampireMode = argMap.get("mode").get(0).toUpperCase();
+        int timeout = 30;
+        if (argMap.containsKey("timeout") && !argMap.get("timeout").isEmpty()) {
+            try {
+                timeout = Integer.parseInt(argMap.get("timeout").get(0));
+            }
+            catch (NumberFormatException nfe) {
+                System.err.println("Invalid timeout: " + argMap.get("timeout").get(0));
+                return;
+            }
+        }
+        int maxAnswers = 1;
+        if (argMap.containsKey("answers") && !argMap.get("answers").isEmpty()) {
+            try {
+                maxAnswers = Integer.parseInt(argMap.get("answers").get(0));
+            }
+            catch (NumberFormatException nfe) {
+                System.err.println("Invalid answers value: " + argMap.get("answers").get(0));
+                return;
+            }
+        }
+        boolean cwa = argMap.containsKey("cwa") || argMap.containsKey("CWA");
+        boolean modusPonens = argMap.containsKey("mp") || argMap.containsKey("modusPonens");
+        boolean dropOnePremise = argMap.containsKey("dropOnePremise");
+        boolean holUseModals = argMap.containsKey("modal");
+        if (!"FOF".equals(lang) && !"TFF".equals(lang) && !"THF".equals(lang)) {
+            System.err.println("Invalid language: " + lang + ". Use --lang fof, --lang tff, or --lang thf.");
+            return;
+        }
+        if ("EPROVER".equals(proverType)) {
+            if ("THF".equals(lang)) {
+                System.err.println("EProver does not support THF/HOL in this controller. Use --lang fof or --lang tff.");
+                return;
+            }
+            if (argMap.containsKey("mode") || cwa || modusPonens || dropOnePremise || holUseModals) {
+                System.err.println("Invalid option for EProver. --mode, --cwa, --mp, --dropOnePremise, and --modal are Vampire-only.");
+                return;
+            }
+            vampireMode = null;
+        }
+        if ("LEO".equals(proverType)) {
+            if (argMap.containsKey("lang") && !"THF".equals(lang)) {
+                System.err.println("LEO should be used with THF/HOL. Do not use --lang fof or --lang tff.");
+                return;
+            }
+            if (argMap.containsKey("mode") || cwa || modusPonens || dropOnePremise || holUseModals) {
+                System.err.println("Invalid option for LEO. --mode, --cwa, --mp, --dropOnePremise, and --modal are Vampire-only.");
+                return;
+            }
+            lang = "THF";
+            vampireMode = null;
+        }
+        if ("VAMPIRE".equals(proverType)) {
+            if (!"CASC".equals(vampireMode) && !"AVATAR".equals(vampireMode) && !"VAMPIRE".equals(vampireMode) && !"CUSTOM".equals(vampireMode)) {
+                System.err.println("Invalid Vampire mode: " + vampireMode + ". Use casc, avatar, vampire, or custom.");
+                return;
+            }
+            if (dropOnePremise && !modusPonens) {
+                System.err.println("--dropOnePremise requires --mp.");
+                return;
+            }
+            if (holUseModals && !"THF".equals(lang)) {
+                System.err.println("--modal only applies with --lang thf.");
+                return;
+            }
+        }
         ATPQuery atpQuery = new ATPQuery(
-            kb, 
-            null, 
-            "", 
-            null, 
-            "CUSTOM", 
-            "VAMPIRE", 
-            "FOF", 
-            "CASC", 
-            false, 
-            false, 
-            false, 
-            false, 
-            30, 
-            1
-        );
-        if (argMap.containsKey("v") && argMap.get("v").size() == 1) {
-            String queryString = String.join(" ", argMap.get("v"));
-            atpQuery = new ATPQuery(
-                kb, 
-                null, 
-                queryString, 
-                null, 
-                "CUSTOM", 
-                "VAMPIRE", 
-                "FOF", 
-                "CASC", 
-                false, 
-                false, 
-                false, 
-                false, 
-                30, 
-                1
-            );
-            System.out.println("TheoremProverController.main(): Result=\n" + theoremProverController.ask(atpQuery).toString());
-        }
-        if (argMap.containsKey("e") && argMap.get("e").size() == 1) {
-            String queryString = String.join(" ", argMap.get("e"));
-            atpQuery = new ATPQuery(
-                kb, 
-                null, 
-                queryString, 
-                null, 
-                "CUSTOM",
-                "EPROVER", 
-                "FOF", 
+                kb,
                 null,
-                false, 
-                false, 
-                false, 
-                false, 
-                30, 
-                1
-            );
-            System.out.println("TheoremProverController.main(): Result=\n" + theoremProverController.ask(atpQuery).toString());
-        }
+                queryString,
+                null,
+                "CUSTOM",
+                proverType,
+                lang,
+                vampireMode,
+                cwa,
+                modusPonens,
+                dropOnePremise,
+                holUseModals,
+                timeout,
+                maxAnswers
+        );
+        TheoremProverController theoremProverController = new TheoremProverController();
         ATPResult result = theoremProverController.ask(atpQuery);
+        if (result == null) {
+            System.err.println("No ATPResult returned. Query may not have translated, or the prover may not have run.");
+            return;
+        }
         System.out.println("TheoremProverController.main(): Summary=");
         System.out.println(result.getSummary());
-        System.out.println("\nRaw Vampire output:");
+        System.out.println("\nRaw prover output:");
         for (String line : result.getStdout()) System.out.println(line);
         TPTP3ProofProcessor tpp = new TPTP3ProofProcessor();
         tpp.parseProofOutput(result.getStdout(), atpQuery.getQuery(), kb, result.getQList());
@@ -217,5 +302,6 @@ public class TheoremProverController {
         System.out.println(tpp.bindingMap);
         System.out.println("\nProof steps:");
         System.out.println(tpp.proof == null ? 0 : tpp.proof.size());
+        LoggingUtils.log("INFO", "Query Result: " + result.getSummary());
     }
 }

--- a/src/java/com/articulate/sigma/tp/TheoremProverController.java
+++ b/src/java/com/articulate/sigma/tp/TheoremProverController.java
@@ -15,9 +15,12 @@ package com.articulate.sigma.tp;
 
 import com.articulate.sigma.KB;
 import com.articulate.sigma.KBmanager;
+
+import com.articulate.sigma.utils.LoggingUtils;
 import com.articulate.sigma.tp.ATPQuery.ATPType;
 import com.articulate.sigma.tp.ATPQuery.RunSource;
 import com.articulate.sigma.tp.ATPQuery.TptpLanguage;
+import com.articulate.sigma.trans.TPTP3ProofProcessor;
 import com.articulate.sigma.parsing.CLIMapParser;
 
 import java.util.ArrayList;
@@ -144,11 +147,28 @@ public class TheoremProverController {
             System.out.println("Available Provers: " + TheoremProverController.availableProvers());
             return;
         }
-        if (argMap.containsKey("v")) {
-            ATPQuery atpQuery = new ATPQuery(
+        ATPQuery atpQuery = new ATPQuery(
+            kb, 
+            null, 
+            "", 
+            null, 
+            "CUSTOM", 
+            "VAMPIRE", 
+            "FOF", 
+            "CASC", 
+            false, 
+            false, 
+            false, 
+            false, 
+            30, 
+            1
+        );
+        if (argMap.containsKey("v") && argMap.get("v").size() == 1) {
+            String queryString = String.join(" ", argMap.get("v"));
+            atpQuery = new ATPQuery(
                 kb, 
                 null, 
-                "(instance ?X Relation)", 
+                queryString, 
                 null, 
                 "CUSTOM", 
                 "VAMPIRE", 
@@ -163,11 +183,12 @@ public class TheoremProverController {
             );
             System.out.println("TheoremProverController.main(): Result=\n" + theoremProverController.ask(atpQuery).toString());
         }
-        if (argMap.containsKey("e")) {
-            ATPQuery atpQuery = new ATPQuery(
+        if (argMap.containsKey("e") && argMap.get("e").size() == 1) {
+            String queryString = String.join(" ", argMap.get("e"));
+            atpQuery = new ATPQuery(
                 kb, 
                 null, 
-                "(instance ?X Relation)", 
+                queryString, 
                 null, 
                 "CUSTOM",
                 "EPROVER", 
@@ -182,5 +203,19 @@ public class TheoremProverController {
             );
             System.out.println("TheoremProverController.main(): Result=\n" + theoremProverController.ask(atpQuery).toString());
         }
+        ATPResult result = theoremProverController.ask(atpQuery);
+        System.out.println("TheoremProverController.main(): Summary=");
+        System.out.println(result.getSummary());
+        System.out.println("\nRaw Vampire output:");
+        for (String line : result.getStdout()) System.out.println(line);
+        TPTP3ProofProcessor tpp = new TPTP3ProofProcessor();
+        tpp.parseProofOutput(result.getStdout(), atpQuery.getQuery(), kb, result.getQList());
+        tpp.processAnswersFromProof(result.getQList(), atpQuery.getQuery());
+        System.out.println("\nBindings:");
+        System.out.println(tpp.bindings);
+        System.out.println("\nBinding map:");
+        System.out.println(tpp.bindingMap);
+        System.out.println("\nProof steps:");
+        System.out.println(tpp.proof == null ? 0 : tpp.proof.size());
     }
 }

--- a/test/corpus/java/com/articulate/sigma/inference/InferenceTest.java
+++ b/test/corpus/java/com/articulate/sigma/inference/InferenceTest.java
@@ -106,7 +106,7 @@ public class InferenceTest {
     public void test() {
 
         System.out.println("InferenceTest.test(): " + fInput);
-        InferenceTestSuite its = new InferenceTestSuite();
+        InferenceTestSuite its = new InferenceTestSuite(kb);
         InferenceTestSuite.InfTestData itd = its.inferenceUnitTest(fInput,kb);
         System.out.println("expected: " + itd.expectedAnswers);
         System.out.println("actual: " + itd.actualAnswers);


### PR DESCRIPTION
Updated the main in TheoremProverController to enable the full range of options for running Vampire, E, and LEO.

Use this to submit a query to vampire with default timeout and maxAnswers in fof:
java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -v "(subclass ?x Object)"

Use the following to add a flag option for vampire mode:
java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -v "(subclass ?X Object)" --mode avatar

Use the following to add a flag option for different languages:
java -cp build/classes:lib/* com.articulate.sigma.tp.TheoremProverController -v "(subclass ?X Object)" --lang thf