### PR TITLE
Server Health Checker Class

### DIFF
--- a/src/java/com/articulate/sigma/ServerHealthChecker.java
+++ b/src/java/com/articulate/sigma/ServerHealthChecker.java
@@ -1,0 +1,204 @@
+package com.articulate.sigma;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.articulate.sigma.security.ValidationUtils;
+import com.articulate.sigma.user.EmailService;
+
+public class ServerHealthChecker {
+
+    private static final List<String> URLS = List.of(
+            "https://fsg.nps.edu/sigma/KBs.jsp",
+            "https://ontology.nps.edu/sigma/KBs.jsp",
+            "https://sigma.ontologyportal.org/sigma/KBs.jsp"
+    );
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    /********************************************************************
+     * Runs one health check and sends an email only if one or more URLs are down.
+     */
+    private void run() {
+
+        List<String> downUrls = new ArrayList<>();
+        Map<String, String> failureReasons = new LinkedHashMap<>();
+        for (String url : URLS) {
+            CheckResult result = checkWithRetries(url);
+            String status = result.ok ? "UP" : "DOWN";
+            if (!result.ok) {
+                downUrls.add(url);
+                failureReasons.put(url, result.reason);
+            }
+        }
+        if (downUrls.isEmpty()) {
+            System.out.println("All SigmaKEE URLs are up. No email sent.");
+            return;
+        }
+        sendDownEmail(downUrls, failureReasons);
+    }
+
+    /********************************************************************
+     * Checks all configured URLs and prints results without sending email.
+     */
+    private void dryRun() {
+
+        System.out.println("ServerHealthChecker dry run");
+        System.out.println("No email will be sent.");
+        System.out.println();
+        for (String url : URLS) {
+            CheckResult result = checkWithRetries(url);
+            String status = result.ok ? "UP" : "DOWN";
+            System.out.println(status + "  " + url);
+            System.out.println("      " + result.reason);
+        }
+    }
+
+    private CheckResult checkWithRetries(String url) {
+
+        CheckResult lastResult = null;
+        for (int i = 1; i <= MAX_ATTEMPTS; i++) {
+            lastResult = checkOnce(url);
+            if (lastResult.ok) return lastResult;
+            if (i < MAX_ATTEMPTS) {
+                try {
+                    Thread.sleep(3000L);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return new CheckResult(false, "Interrupted while retrying");
+                }
+            }
+        }
+
+        return lastResult;
+    }
+
+    private CheckResult checkOnce(String url) {
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(20))
+                    .GET()
+                    .header("User-Agent", "SigmaKEE-HealthCheck/1.0")
+                    .build();
+            HttpResponse<String> response = client.send(
+                    request,
+                    HttpResponse.BodyHandlers.ofString()
+            );
+            int status = response.statusCode();
+            String body = response.body() == null ? "" : response.body();
+            if (status == 503) return new CheckResult(false, "HTTP 503 Service Unavailable");
+            String lowerBody = body.toLowerCase(Locale.ROOT);
+            if (lowerBody.contains("service unavailable") || lowerBody.contains("temporarily unable to service your request")) return new CheckResult(false, "Service unavailable page detected");
+            if (status < 200 || status >= 400) return new CheckResult(false, "Unexpected HTTP status: " + status);
+            return new CheckResult(true, "OK HTTP " + status);
+        }
+        catch (IOException e) {
+            return new CheckResult(false, "I/O error: " + e.getMessage());
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new CheckResult(false, "Interrupted");
+        }
+        catch (Exception e) {
+            return new CheckResult(false, "Unexpected error: " + e.getMessage());
+        }
+    }
+
+    private void sendDownEmail(List<String> downUrls, Map<String, String> failureReasons) {
+
+        String subject = "[SigmaKEE Alert] Service unavailable";
+        StringBuilder body = new StringBuilder();
+        body.append("One or more SigmaKEE URLs appear to be down.\n\n");
+        body.append("Time: ").append(Instant.now()).append(" UTC\n\n");
+        for (String url : downUrls) {
+            body.append("DOWN: ").append(url).append("\n");
+            body.append("Reason: ").append(failureReasons.get(url)).append("\n\n");
+        }
+        body.append("This alert was generated by the SigmaKEE URL health checker.\n");
+        sendEmail(subject, body.toString());
+    }
+
+    /********************************************************************
+     * Sends a health checker email to all SigmaKEE admin users.
+     * @param subject the email subject
+     * @param body the plain text email body
+     */
+    private void sendEmail(String subject, String body) {
+
+        KBmanager.getMgr().initializeOnce();
+        String htmlBody =
+                "<h2>SigmaKEE Server Health Check</h2>" +
+                "<pre style='font-family:monospace;white-space:pre-wrap'>" +
+                ValidationUtils.sanitizeString(body) +
+                "</pre>" +
+                "<hr>" +
+                "<p style='font-size:12px;color:#666'>This email was generated automatically by SigmaKEE.</p>";
+        EmailService emailService = new EmailService();
+        boolean sent = emailService.sendAdminNotification(subject, htmlBody);
+    }
+
+    private record CheckResult(boolean ok, String reason) {
+    }
+
+    /********************************************************************
+     * Prints command-line usage options for ServerHealthChecker.
+     */
+    private static void showHelp() {
+
+        System.out.println("ServerHealthChecker:");
+        System.out.println("  -h, --help          Show this help message");
+        System.out.println("  -d, --dry-run       Check URLs and print results without sending email");
+        System.out.println("  -c, --cron          Run normal check; sends email only if one or more URLs are down");
+        System.out.println();
+        System.out.println("If no argument is provided, --cron mode is used.");
+    }
+
+    /********************************************************************
+     * Command line entry point for server health checks.
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+
+        ServerHealthChecker checker = new ServerHealthChecker();
+        if (args == null || args.length == 0) {
+            checker.run();
+            return;
+        }
+        switch (args[0]) {
+            case "-h":
+            case "--help":
+                showHelp();
+                break;
+            case "-d":
+            case "--dry-run":
+                checker.dryRun();
+                break;
+            case "-c":
+            case "--cron":
+                checker.run();
+                break;
+            default:
+                System.err.println("Unknown option: " + args[0]);
+                showHelp();
+                System.exit(1);
+        }
+    }
+}

--- a/src/java/com/articulate/sigma/tp/TheoremProverController.java
+++ b/src/java/com/articulate/sigma/tp/TheoremProverController.java
@@ -119,28 +119,6 @@ public class TheoremProverController {
         return leo.getResult();
     }
 
-
-    public ATPResult runTestFile(KB kb, String testFilePath, String proverType, String language, String vampireMode, boolean closedWorldAssumption, boolean modusPonens, boolean dropOnePremise, boolean holUseModals, int timeout) {
-
-        ATPQuery atpQuery = new ATPQuery(
-            kb,
-            null,
-            null,
-            testFilePath,
-            "TEST_FILE",
-            proverType,
-            language,
-            vampireMode,
-            closedWorldAssumption,
-            modusPonens, 
-            dropOnePremise,
-            holUseModals,
-            timeout, 
-            1
-        );
-        return ask(atpQuery);
-    }
-
     /********************************************************************
      * Prints the main() console options for this class.
      */

--- a/src/java/com/articulate/sigma/user/EmailService.java
+++ b/src/java/com/articulate/sigma/user/EmailService.java
@@ -48,6 +48,66 @@ public class EmailService {
     }
 
     /********************************************************************
+     * Sends a generic HTML notification email to all admin users.
+     * @param subject the email subject
+     * @param htmlBody the HTML body
+     * @return true if the email was sent successfully
+     */
+    public boolean sendAdminNotification(String subject, String htmlBody) {
+
+        UserDatabase userDatabase = new UserDatabase();
+        try {
+            List<String> adminEmails = userDatabase.getAdminEmails();
+            return sendHtmlEmail(adminEmails, subject, htmlBody);
+        }
+        finally {
+            userDatabase.close();
+        }
+    }
+
+    /********************************************************************
+     * Sends a generic HTML email to the given recipients.
+     * @param recipients the email recipient addresses
+     * @param subject the email subject
+     * @param htmlBody the HTML body
+     * @return true if the email was sent successfully
+     */
+    public boolean sendHtmlEmail(List<String> recipients, String subject, String htmlBody) {
+
+        if (recipients == null || recipients.isEmpty()) {
+            System.err.println("ERROR: No email recipients provided.");
+            return false;
+        }
+        if (StringUtil.emptyString(subject)) {
+            System.err.println("ERROR: Cannot send email with empty subject.");
+            return false;
+        }
+        if (StringUtil.emptyString(htmlBody)) {
+            System.err.println("ERROR: Cannot send email with empty body.");
+            return false;
+        }
+        if (!isSmtpConfigured()) {
+            printSmtpConfigurationError();
+            return false;
+        }
+
+        try {
+            MimeMessage message = new MimeMessage(createMailSession());
+            message.setFrom(new InternetAddress(smtpEmailAddress));
+            message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(String.join(",", recipients)));
+            message.setSubject(subject, StandardCharsets.UTF_8.name());
+            message.setContent(htmlBody, "text/html; charset=UTF-8");
+            Transport.send(message);
+            return true;
+        }
+        catch (MessagingException me) {
+            System.err.println("ERROR: Unable to send email.");
+            me.printStackTrace();
+            return false;
+        }
+    }
+
+    /********************************************************************
      * Sends an account registration approval request email to the moderators.
      * @param user the user requesting registration
      * @param adminEmails the moderator/admin email addresses

--- a/src/java/com/articulate/sigma/user/UserDatabase.java
+++ b/src/java/com/articulate/sigma/user/UserDatabase.java
@@ -255,20 +255,22 @@ public class UserDatabase {
     public List<String> getAdminEmails() {
 
         List<String> adminEmails = new ArrayList<>();
-        try (Statement query = connection.createStatement();
-            ResultSet resultSet = query.executeQuery("SELECT username FROM users WHERE role='admin';")) {
+        String sql = """
+            SELECT email
+            FROM users
+            WHERE LOWER(role) = 'admin'
+            AND email IS NOT NULL
+            AND TRIM(email) <> ''
+            """;
+        try (PreparedStatement statement = this.connection.prepareStatement(sql);
+            ResultSet resultSet = statement.executeQuery()) {
             while (resultSet.next()) {
-                String username = resultSet.getString(1);
-                User user = fromDB(username);
-                if (user != null) {
-                    String adminEmail = user.getEmail();
-                    if (adminEmail != null && !adminEmail.trim().isEmpty()) adminEmails.add(adminEmail.trim());
-                    else System.err.println("WARNING: Admin user " + username + " has no valid email.");
-                }
+                String adminEmail = resultSet.getString("email");
+                if (adminEmail != null && !adminEmail.trim().isEmpty()) adminEmails.add(adminEmail.trim());
             }
         }
         catch (SQLException e) {
-            System.err.println("Error in getAdminEmails(): " + e.getMessage());
+            System.err.println("Error in UserDatabase.getAdminEmails(): " + e.getMessage());
             e.printStackTrace();
         }
         return adminEmails;
@@ -585,6 +587,20 @@ public class UserDatabase {
         }
         catch (SQLException e) {
             System.err.println(H2_DRIVER + " shutdown issues: " + e.getLocalizedMessage());
+        }
+    }
+
+    /********************************************************************
+     * Closes the H2 database connection without shutting down the database.
+     */
+    public void close() {
+
+        try {
+            if (this.connection != null && !this.connection.isClosed()) this.connection.close();
+        }
+        catch (SQLException e) {
+            System.err.println("Error in UserDatabase.close(): " + e.getMessage());
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Created a server health checker class that will check each of the server urls listed in the file (ontology, fsg, sigma.ontologyportal) and send an email to all admins if one or more is down.

This file is intended to be run by a cron job set up on each of the servers, so when one goes down the other will detect it.

1) Create a health checking shell script.
```bash
nano /usr/local/sbin/sigmakee-healthcheck.sh
```

Save this into that file:
```bash
#!/usr/bin/env bash
set -euo pipefail

export SIGMA_HOME="/var/lib/sigmakee-data/.sigmakee"
export CATALINA_HOME="/opt/sigmakee-runtime/apache-tomcat"

cd /srv/sigmakee-software/sigmakee

/usr/bin/java \
  -Duser.home=/var/lib/sigmakee-data \
  -DSIGMA_HOME=/var/lib/sigmakee-data/.sigmakee \
  -cp "build/classes:lib/*" \
  com.articulate.sigma.ServerHealthChecker --cron
```

2) Make it executable for all users
```bash
sudo chmod 755 /usr/local/sbin/sigmakee-healthcheck.sh
```

3) Create a cronjob to run the script every hour
```bash
sudo nano /etc/cron.d/sigmakee-healthcheck
```

```bash
SHELL=/bin/bash
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

*/60 * * * * root flock -n /var/lock/sigmakee-healthcheck.lock /usr/local/sbin/sigmakee-healthcheck.sh >> /var/log/sigmakee-healthcheck.log 2>&1

```

4) Create a log for it to print to
```bash
sudo touch /var/log/sigmakee-healthcheck.log
sudo chmod 644 /var/log/sigmakee-healthcheck.log
```

You can test it locally by running:
```bash
java -cp "build/classes:lib/*" com.articulate.sigma.ServerHealthChecker
```