### PR TITLE
Fix Modals.java for handling Deontics, and add RIGID_RELATIONS

### DIFF
--- a/src/java/com/articulate/sigma/trans/Modals.java
+++ b/src/java/com/articulate/sigma/trans/Modals.java
@@ -161,12 +161,19 @@ public class Modals {
                     "trichotomizingOn",
                     "totalOrderingOn",
                     "disjointDecomposition", // New Entry (Angelos)
-                    // CF: TODO: Include all temporals other than the SEVEN: 
-                    // weddingAnniversary, typicallyContainsTemporalPart, typicalTemporalPart
-                    // time, cooccur, anniversary, WhenFn 
                     "AfternoonFn",
                     "MorningFn",
                     "EveningFn", 
+                    // CF: Include all temporals other than the SEVEN: 
+                    // weddingAnniversary, typicallyContainsTemporalPart, typicalTemporalPart
+                    // time, cooccur, anniversary, WhenFn 
+                    "weddingAnniversary",
+                    "typicallyContainsTemporalPart",
+                    "typicalTemporalPart",
+                    "time",
+                    "coocur",
+                    "anniversary",
+                    "WhenFn",
                     // Arithmetic Op
                     "AbsoluteValueFn", 
                     "AdditionFn",

--- a/src/java/com/articulate/sigma/trans/Modals.java
+++ b/src/java/com/articulate/sigma/trans/Modals.java
@@ -139,6 +139,13 @@ public class Modals {
             "Illegal",
             "Promise"
     ));
+    
+    //CF: Single Deontic attributes added here
+    public static final Set<String> deonticAttributes = new HashSet<>(Arrays.asList(
+            "Permission",
+            "Obligation",
+            "Prohibition"
+    ));
 
     // Relations that are treated as *rigid* in the Kripke semantics:
     // they do NOT get a world argument in their THF type. These are
@@ -989,6 +996,7 @@ public class Modals {
 
         StringBuilder result = new StringBuilder();
         HashSet<String> allModals = new HashSet<>();
+        allModals.addAll(deonticAttributes);     // CF: O, F, and P have been added
         allModals.addAll(regHOLpred);
         allModals.addAll(regHOL3pred);
         result.append(genModalTypes(allModals));
@@ -1001,8 +1009,10 @@ public class Modals {
                 result.append(genModalSystem(s, ModalSystem.D4));
             } else if (deontic_P.contains(s)) {
                 result.append(genModalSystem(s, ModalSystem.K));
-            } else if (deontic_other.contains(s)) {     // CF: TODO for confers/deprivesNorm
+            // CF: TODO: confers/deprivesNorm will act like modalAttribute
+            } else if (deontic_other.contains(s)) {
                 result.append(genModalSystem(s, ModalSystem.D));
+            // All other modal systems:
             } else {
                 result.append(genModalSystem(s, ModalSystem.T));
             }
@@ -1062,9 +1072,17 @@ public class Modals {
 
         //System.out.println("Modals.genFrameAxiom(): modalOp: " + modalOp);
         //System.out.println("Modals.genFrameAxiom(): frameAx: " + frameAx);
+        
+        //CF: Check whether this is Obligation, Prohibition, Permission
+        boolean isAttr = false;
+        String name = "";
+        
         String quantArgs = "";
         String args = "";
         String accreln = "s__accreln1";
+        if (deonticAttributes.contains(modalOp)) {
+            isAttr = true;
+        }
         if (regHOLpred.contains(modalOp)) {
             quantArgs = ", P1:$i";
             args = " @ P1";
@@ -1082,24 +1100,32 @@ public class Modals {
                 accreln = "s__accreln3";
             }
         }
+        
+        // CF: If Attribute, convert first char to lowercase
+        if (isAttr) {
+            name = modalOp.toLowerCase();
+        } else {
+            name = modalOp;
+        }
+        
         switch (frameAx) {
             case REFLEXIVE:
-                return "thf(" + modalOp + "_refl" + ",axiom,(! [W:w" + quantArgs +
+                return "thf(" + name + "_refl" + ",axiom,(! [W:w" + quantArgs +
                         "] : (" + accreln + " @ s__" + modalOp + args + " @ W @ W))).\n";
             case SYMMETRIC:
-                return "thf(" + modalOp + "_symm" + ",axiom,(! [W1:w, W2:w" + quantArgs +
+                return "thf(" + name + "_symm" + ",axiom,(! [W1:w, W2:w" + quantArgs +
                         "] : ((" + accreln + " @ s__" + modalOp + args + " @ W1 @ W2) => " +
                         "(" + accreln + " @ s__" + modalOp + args + " @ W2 @ W1)))).\n";
             case TRANSITIVE:
-                return "thf(" + modalOp + "_trans" + ",axiom,(! [W1:w, W2:w, W3:w" + quantArgs +
+                return "thf(" + name + "_trans" + ",axiom,(! [W1:w, W2:w, W3:w" + quantArgs +
                         "] : (((" + accreln + " @ s__" + modalOp + args + " @ W1 @ W2) & " +
                         "(" + accreln + " @ s__" + modalOp + args + " @ W2 @ W3)) => " +
                         "(" + accreln + " @ s__" + modalOp + args + " @ W1 @ W3)))).\n";
             case SERIAL:
-                return "thf(" + modalOp + "_ser,axiom,(! [W:w" + quantArgs +
+                return "thf(" + name + "_ser,axiom,(! [W:w" + quantArgs +
                         "] : (? [U:w] : (" + accreln + " @ s__" + modalOp + args + " @ W @ U)))).\n";
             case EUCLIDEAN:
-                return "thf(" + modalOp + "_eucl,axiom,(! [W1:w, W2:w, W3:w" + quantArgs +
+                return "thf(" + name + "_eucl,axiom,(! [W1:w, W2:w, W3:w" + quantArgs +
                     "] : (((" + accreln + " @ s__" + modalOp + args + " @ W1 @ W2) & " +
                     "(" + accreln + " @ s__" + modalOp + args + " @ W1 @ W3)) => " +
                     "(" + accreln + " @ s__" + modalOp + args + " @ W2 @ W3)))).\n";
@@ -1116,10 +1142,6 @@ public class Modals {
         return 
                 // CF: add these lines into getTHFHeader() result string
                 "thf(modals_tp,type,(m : $tType)).\n" +
-                //"thf(obligation_tp,type,(s__Obligation : m)).\n" +
-                //"thf(permission_tp,type,(s__Permission : m)).\n" +
-                //"thf(prohibition_tp,type,(s__Prohibition : m)).\n" +
-                
                 "thf(worlds_tp,type,(w : $tType)).\n" +
                 "thf(cworld_tp,type,(s__CW : w)).\n" +
                 "thf(s__worlds_tp,type,(s__World : w)).\n" +

--- a/src/java/com/articulate/sigma/trans/Modals.java
+++ b/src/java/com/articulate/sigma/trans/Modals.java
@@ -284,6 +284,16 @@ public class Modals {
             "confersNorm", "confersObligation", "confersRight", "deprivesNorm", "Obligation",
             "Permission", "Prohibition", "holdsObligation", "holdsRight", "permits","prohibits",
             "Legal", "Law", "Illegal", "Promise"));
+    // CF: Added for Deontics' granularity from CHAD tests: O/F vs. P
+    public static final Set<String> deontic_O_F = new HashSet<>(Arrays.asList(
+            "Obligation", "Prohibition", 
+            "confersObligation", "holdsObligation", "prohibits"));
+    public static final Set<String> deontic_P = new HashSet<>(Arrays.asList(
+            "Permission", 
+            "confersRight", "holdsRight", "permits"));
+    public static final Set<String> deontic_other = new HashSet<>(Arrays.asList(
+            "confersNorm", "deprivesNorm",  // CF: Should these be like modalAttribute?
+            "Legal", "Law", "Illegal", "Promise"));
     public static final Set<String> epistemic = new HashSet<>(Arrays.asList(
             "believes", "knows", "desires", "says", "describes", "expects"));
     public static final Set<String> otherModal = new HashSet<>(Arrays.asList(
@@ -984,10 +994,18 @@ public class Modals {
         result.append(genModalTypes(allModals));
         //System.out.println("Modals.genAllModalSystems(): allModals size: " + allModals.size());
         for (String s : allModals) {
-            if (deontics.contains(s))
+            //CF: Deontics are split between O/F vs. P according the CHAD example findings
+            /*if (deontics.contains(s))
+                result.append(genModalSystem(s, ModalSystem.D));*/
+            if (deontic_O_F.contains(s)) {
+                result.append(genModalSystem(s, ModalSystem.D4));
+            } else if (deontic_P.contains(s)) {
+                result.append(genModalSystem(s, ModalSystem.K));
+            } else if (deontic_other.contains(s)) {     // CF: TODO for confers/deprivesNorm
                 result.append(genModalSystem(s, ModalSystem.D));
-            else
+            } else {
                 result.append(genModalSystem(s, ModalSystem.T));
+            }
         }
         return result.toString();
     }
@@ -1021,7 +1039,9 @@ public class Modals {
                     genFrameAxiom(modalOp,FrameAx.EUCLIDEAN);
             case D4: return genFrameAxiom(modalOp,FrameAx.TRANSITIVE) +
                     genFrameAxiom(modalOp,FrameAx.SERIAL);
-            case D45: return genFrameAxiom(modalOp,FrameAx.TRANSITIVE) +
+            // CF: Euclidean was missing, it has been added here - 08 Jul
+            case D45: return genFrameAxiom(modalOp, FrameAx.EUCLIDEAN) + 
+                    genFrameAxiom(modalOp,FrameAx.TRANSITIVE) +
                     genFrameAxiom(modalOp,FrameAx.SERIAL);
         }
         return result;


### PR DESCRIPTION
* Add to RIGID_RELATIONS: 
weddingAnniversary, typicallyContainsTemporalPart, typicalTemporalPart, time, cooccur, anniversary, WhenFn 

* Add subset of deontics that is only the three attributes, "deonticAttributes": Obligation, Prohibition, and Permission

* Split deontic (no 's') into deontic_O_F (for obligation and prohibition-based terms) and deontic_P (for permission-based terms).
* genAllModalSystems now discriminates O/F vs. P
