### PR TITLE
Updated KB Statistics to not count cached formulas

### DIFF
--- a/src/java/com/articulate/sigma/KB.java
+++ b/src/java/com/articulate/sigma/KB.java
@@ -2156,14 +2156,14 @@ public class KB implements Serializable {
     }
 
     /*****************************************************************
-     * Count the number of formulas in the knowledge base in order to present statistics
-     * to the user.
-     *
+     * Count the number of formulas in the knowledge base in order to present statistics to the user.
      * @return The int(eger) number of formulas in the knowledge base.
      */
     public int getCountAxioms() {
-        
-        return formulaMap.size();
+
+        int count = 0;
+        for (Formula f : formulaMap.values()) if (!f.isCached()) count++;
+        return count;
     }
 
     /*****************************************************************
@@ -2199,10 +2199,7 @@ public class KB implements Serializable {
     public int getCountRules() {
 
         int count = 0;
-        for (Formula f : formulaMap.values()) {
-            if (f.isRule())
-                count++;
-        }
+        for (Formula f : formulaMap.values()) if (!f.isCached() && f.isRule()) count++;
         return count;
     }
 

--- a/src/java/com/articulate/sigma/KButilities.java
+++ b/src/java/com/articulate/sigma/KButilities.java
@@ -431,7 +431,9 @@ public class KButilities implements ServletContextListener {
 
         Map<String,Integer> result = new HashMap<>();
         for (Formula f : kb.formulaMap.values()) {
-            Set<String> terms = f.collectTerms();
+            if (f.isCached())
+                continue;
+
             if (f.isRule()) {
                 MapUtils.addToFreqMap(result, "rules", 1);
                 if (f.isHorn(kb))
@@ -447,16 +449,15 @@ public class KButilities implements ServletContextListener {
                     else if (f.isTemporal(kb))
                         MapUtils.addToFreqMap(result, "temporal", 1);
                 }
-                else
-                    MapUtils.addToFreqMap(result, "first-order", 1);
+                else MapUtils.addToFreqMap(result, "first-order", 1);
             }
             else {
                 if (f.isGround())
-                    MapUtils.addToFreqMap(result,"ground",1);
+                    MapUtils.addToFreqMap(result, "ground", 1);
                 if (f.isBinary())
-                    MapUtils.addToFreqMap(result,"binary",1);
+                    MapUtils.addToFreqMap(result, "binary", 1);
                 else
-                    MapUtils.addToFreqMap(result,"higher-arity",1);
+                    MapUtils.addToFreqMap(result, "higher-arity", 1);
             }
         }
         return result;
@@ -1257,11 +1258,9 @@ public class KButilities implements ServletContextListener {
         rels.add("termFormat");
         rels.add("format");
         int counter = 0;
-        Set<Formula> forms = new HashSet<>();
-        forms.addAll(kb.formulaMap.values());
-        for (Formula f : forms) {
-            if (!rels.contains(f.getArgument(0).toString()))
-                counter++;
+        for (Formula f : kb.formulaMap.values()) {
+            if (f.isCached()) continue;
+            if (!rels.contains(f.getStringArgument(0))) counter++;
         }
         return counter;
     }


### PR DESCRIPTION
KB.getCountAxioms(), KB.getCountRules(), KButilities.countFormulaTypes(), and KButilities.getCountNonLinguisticAxioms() now exclude cached formulas using Formula.isCached().